### PR TITLE
Update tokio to stable release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 [dependencies]
 async-trait = "0.1.17"
-tokio = "0.2.0-alpha.6"
+tokio = { version = "0.2.1", features = ["sync"] }
 
 [workspace]
 members = [


### PR DESCRIPTION
Updates tokio to 0.2.1 and adds the `sync` feature.  Seems to fix #1.