### PR TITLE
Remove call to `to_owned` in statement cache

### DIFF
--- a/postgres/src/lib.rs
+++ b/postgres/src/lib.rs
@@ -43,8 +43,8 @@ use futures::FutureExt;
 use log::{info, warn};
 use tokio::spawn;
 use tokio_postgres::{
-    tls::MakeTlsConnect, tls::TlsConnect, Client as PgClient, Config as PgConfig, Error, Socket,
-    Statement, Transaction as PgTransaction, types::Type
+    tls::MakeTlsConnect, tls::TlsConnect, types::Type, Client as PgClient, Config as PgConfig,
+    Error, Socket, Statement, Transaction as PgTransaction,
 };
 
 /// A type alias for using `deadpool::Pool` with `tokio_postgres`
@@ -152,9 +152,7 @@ impl ClientWrapper {
             Some(statement) => Ok(statement.clone()),
             None => {
                 let stmt = self.client.prepare_typed(query, types).await?;
-                self.statement_cache
-                    .map
-                    .insert(key, stmt.clone());
+                self.statement_cache.map.insert(key, stmt.clone());
                 Ok(stmt)
             }
         }
@@ -207,9 +205,7 @@ impl<'a> Transaction<'a> {
             Some(statement) => Ok(statement.clone()),
             None => {
                 let stmt = self.txn.prepare_typed(query, types).await?;
-                self.statement_cache
-                    .map
-                    .insert(key, stmt.clone());
+                self.statement_cache.map.insert(key, stmt.clone());
                 Ok(stmt)
             }
         }

--- a/postgres/tests/postgres.rs
+++ b/postgres/tests/postgres.rs
@@ -65,7 +65,10 @@ async fn test_basic() {
 async fn test_prepare_typed() {
     let pool = create_pool();
     let mut client = pool.get().await.unwrap();
-    let stmt = client.prepare_typed("SELECT 1 + $1", &[Type::INT2]).await.unwrap();
+    let stmt = client
+        .prepare_typed("SELECT 1 + $1", &[Type::INT2])
+        .await
+        .unwrap();
     let rows = client.query(&stmt, &[&42i16]).await.unwrap();
     let value: i32 = rows[0].get(0);
     assert_eq!(value, 43i32);
@@ -76,7 +79,10 @@ async fn test_prepare_typed() {
 async fn test_prepare_typed_error() {
     let pool = create_pool();
     let mut client = pool.get().await.unwrap();
-    let stmt = client.prepare_typed("SELECT 1 + $1", &[Type::INT2]).await.unwrap();
+    let stmt = client
+        .prepare_typed("SELECT 1 + $1", &[Type::INT2])
+        .await
+        .unwrap();
     assert!(client.query(&stmt, &[&42i32]).await.is_err());
 }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -63,7 +63,10 @@ where
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Timeout(tt) => match tt {
-                TimeoutType::Wait => write!(f, "A timeout occured while waiting for a slot to become available"),
+                TimeoutType::Wait => write!(
+                    f,
+                    "A timeout occured while waiting for a slot to become available"
+                ),
                 TimeoutType::Create => write!(f, "A timeout occured while creating a new object"),
                 TimeoutType::Recycle => write!(f, "A timeout occured while recycling an object"),
             },


### PR DESCRIPTION
Avoids allocating a String on each call to `prepare` if it's already in
the cache. Also ran `rustfmt` which changed one line.