### PR TITLE
Update tokio-postgres to 0.5.1

### DIFF
--- a/postgres/Cargo.toml
+++ b/postgres/Cargo.toml
@@ -18,7 +18,7 @@ async-trait = "0.1.17"
 futures = "0.3.1"
 log = "0.4"
 tokio = { version = "0.2.5", features = ["sync"] }
-tokio-postgres = { version = "0.5.0-alpha.2" }
+tokio-postgres = "0.5.1"
 
 [dev-dependencies]
 tokio = { version = "0.2.5", features = ["sync", "macros"] }


### PR DESCRIPTION
Since they've released a non-alpha version