### PR TITLE
impl DerefMut for ClientWrapper

### DIFF
--- a/postgres/src/lib.rs
+++ b/postgres/src/lib.rs
@@ -36,7 +36,7 @@
 #![warn(missing_docs)]
 
 use std::collections::HashMap;
-use std::ops::Deref;
+use std::ops::{Deref, DerefMut};
 
 use async_trait::async_trait;
 use futures::FutureExt;
@@ -168,6 +168,12 @@ impl Deref for ClientWrapper {
     type Target = PgClient;
     fn deref(&self) -> &PgClient {
         &self.client
+    }
+}
+
+impl DerefMut for ClientWrapper {
+    fn deref_mut(&mut self) -> &mut PgClient {
+        &mut self.client
     }
 }
 


### PR DESCRIPTION
While making this change I realized this used to exist, but was removed per [the changelog](https://github.com/bikeshedder/deadpool/blob/master/postgres/CHANGELOG.md#v021):

> v0.2.1
> deadpool_postgres::Client no longer implements DerefMut which was not needed anyways.

It's not immediately clear why it was removed, but is there a suggested alternative way to get a mutable reference to the underlying client?