### PR TITLE
Make deadpool_postgres::config module public

### DIFF
--- a/postgres/CHANGELOG.md
+++ b/postgres/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.5.3 (unreleased)
 
 * Add `#[derive(Clone)]` to `Config` struct
+* Make `config` module public
 
 ## v0.5.2
 

--- a/postgres/src/config.rs
+++ b/postgres/src/config.rs
@@ -1,3 +1,5 @@
+//! This module describes configuration used for [`Pool`] creation.
+
 use std::env;
 use std::fmt;
 use std::path::Path;
@@ -17,6 +19,7 @@ use crate::Pool;
 /// wrong with the configuration.
 #[derive(Debug)]
 pub enum ConfigError {
+    /// Message of the error.
     Message(String),
 }
 
@@ -82,6 +85,7 @@ impl Into<PgSslMode> for SslMode {
     }
 }
 
+/// Channel binding configuration.
 #[derive(Debug, Copy, Clone, PartialEq)]
 #[cfg_attr(feature = "config", derive(serde::Deserialize))]
 #[non_exhaustive]

--- a/postgres/src/lib.rs
+++ b/postgres/src/lib.rs
@@ -42,7 +42,8 @@
 //! - MIT license ([LICENSE-MIT](LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
 //!
 //! at your option.
-#![warn(missing_docs)]
+
+#![warn(missing_docs, unreachable_pub)]
 
 use std::borrow::Cow;
 use std::collections::HashMap;
@@ -59,7 +60,7 @@ use tokio_postgres::{
     Error, Socket, Statement, Transaction as PgTransaction,
 };
 
-mod config;
+pub mod config;
 pub use crate::config::Config;
 
 /// A type alias for using `deadpool::Pool` with `tokio_postgres`


### PR DESCRIPTION
This PR makes `deadpool_postgres::config` public.

## Motivation

At the moment there is quite friction when creating custom wrappers on top of `deadpool-postgres` crate. The problem is that types related to `Config` cannot be imported and used.

For example, [`ConfigError` returned by `Config::create_pool`](https://docs.rs/deadpool-postgres/0.5.2/deadpool_postgres/struct.Config.html#method.create_pool) cannot be used in custom signatures as is unreachable, so the only option left is just to unwrap it, which is not good.

The same with `config::SslMode`, `config::ChannelBinding` and others if you want to create custom mapping to those types.

## Checklist

- [x] `rustfmt`ed
- [x] `cargo test -p deadpool-postgres` pass and no warnings produced
- [x] `postgres/CHANGELOG.md` entry is added