### PR TITLE
Allow nested transactions with deadpool_postgres::Transaction

### DIFF
--- a/postgres/CHANGELOG.md
+++ b/postgres/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## v0.5.4
+
+* Implement `DerefMut` for `Transaction` wrapper
+
 ## v0.5.3
 
 * Add `#[derive(Clone)]` to `Config` struct

--- a/postgres/src/lib.rs
+++ b/postgres/src/lib.rs
@@ -277,3 +277,9 @@ impl<'a> Deref for Transaction<'a> {
         &self.txn
     }
 }
+
+impl<'a> DerefMut for Transaction<'a> {
+    fn deref_mut(&mut self) -> &mut PgTransaction<'a> {
+        &mut self.txn
+    }
+}


### PR DESCRIPTION
This PR adds `DerefMut` implementation for `deadpool_postgres::Transaction` wrapper, so opens nested transactions capability supported by `tokio-postgres`:
- https://docs.rs/tokio-postgres/0.5.1/tokio_postgres/struct.Transaction.html#method.transaction
- https://docs.rs/tokio-postgres/0.5.1/src/tokio_postgres/transaction.rs.html#271-281

## Checklist
- [x] `rustfmt`ed
- [x] `postgres/CHANGELOG.md` entry is added
