### PR TITLE
Upgrade lapin to 1.0.0

### DIFF
--- a/lapin/Cargo.toml
+++ b/lapin/Cargo.toml
@@ -22,7 +22,7 @@ config-crate = { package = "config", version = "0.10.1", default-features = fals
 serde = { version = "1.0", features = ["derive"], optional = true}
 
 [dependencies.lapin]
-version = "0.39.7"
+version = "1.0.0"
 default-features = false
 
 [dev-dependencies]

--- a/lapin/src/config.rs
+++ b/lapin/src/config.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "config")]
-use ::config_crate::{ConfigError, Environment};
+use config_crate::{ConfigError, Environment};
 use deadpool::managed::PoolConfig;
 
 use crate::Pool;

--- a/lapin/src/lib.rs
+++ b/lapin/src/lib.rs
@@ -89,7 +89,7 @@ impl deadpool::managed::Manager<lapin::Connection, Error> for Manager {
         let connection =
             lapin::Connection::connect(self.addr.as_str(), self.connection_properties.clone())
                 .await?;
-        Ok(connection.into_inner())
+        Ok(connection)
     }
     async fn recycle(&self, connection: &mut lapin::Connection) -> RecycleResult {
         match connection.status().state() {


### PR DESCRIPTION
Hey!

Thanks for the great project :+1:.

[lapin](https://crates.io/crates/lapin) has reached `1.0.0` after several rcs and when trying to use this pool with it, there were compatibility issues, since it was still on `0.39.7`.

This would upgrade the dependency to `1.0.0`, which would be nice as it marks a point of API stability for `lapin`.