### PR TITLE
deadpool-redis: Disable redis default features

### DIFF
--- a/redis/CHANGELOG.md
+++ b/redis/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## v0.?.?
 
 * Import `redis` with `default-features = false`.
+* Add `tokio-comp` default feature that enables [tokio](https://crates.io/crates/tokio) async runtime.
+* Add `async-std-comp` feature that enables [async-std](https://crates.io/crates/async-std) async runtime.
 
 ## v0.6.0
 

--- a/redis/CHANGELOG.md
+++ b/redis/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Change Log
 
-## v0.?.?
+## v0.7.0
 
-* Import `redis` with `default-features = false`.
-* Add `tokio-comp` default feature that enables [tokio](https://crates.io/crates/tokio) async runtime.
-* Add `async-std-comp` feature that enables [async-std](https://crates.io/crates/async-std) async runtime.
+* Import [redis](https://crates.io/crates/redis) with `default-features = false`.
+* Add `with-tokio` default feature that enables [tokio](https://crates.io/crates/tokio) async runtime.
+* Add `with-async-std` feature that enables [async-std](https://crates.io/crates/async-std) async runtime.
 
 ## v0.6.0
 

--- a/redis/CHANGELOG.md
+++ b/redis/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## v0.?.?
+
+* Import `redis` with `default-features = false`.
+
 ## v0.6.0
 
 * Update `redis` dependency to version `0.16.0`

--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -15,9 +15,9 @@ all-features = true
 [dependencies]
 deadpool = { path = "../", version = "0.5.0", default-features = false, features = ["managed"] }
 async-trait = "0.1.17"
-futures = { version = "0.3.1", features = ["compat" ] }
+futures = { version = "0.3.1", features = ["compat"] }
 log = "0.4"
-redis = "0.16.0"
+redis = { version = "0.16.0", default-features = false }
 # only required when using the config feature
 config-crate = { package = "config", version = "0.10.1", default-features = false, optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true}

--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -17,7 +17,7 @@ deadpool = { path = "../", version = "0.5.0", default-features = false, features
 async-trait = "0.1.17"
 futures = { version = "0.3.1", features = ["compat"] }
 log = "0.4"
-redis = { version = "0.16.0", default-features = false }
+redis = { version = "0.16.0", default-features = false, features = ["aio"] }
 # only required when using the config feature
 config-crate = { package = "config", version = "0.10.1", default-features = false, optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true}
@@ -27,5 +27,7 @@ tokio = { version = "0.2.9", features = ["macros", "rt-core"] }
 dotenv = "0.15.0"
 
 [features]
-default = ["config"]
+default = ["config", "tokio-comp"]
 config = ["config-crate", "serde", "deadpool/config"]
+tokio-comp = ["redis/tokio-comp"]
+async-std-comp = ["redis/async-std-comp"]

--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -27,7 +27,7 @@ tokio = { version = "0.2.9", features = ["macros", "rt-core"] }
 dotenv = "0.15.0"
 
 [features]
-default = ["config", "tokio-comp"]
+default = ["config", "with-tokio"]
 config = ["config-crate", "serde", "deadpool/config"]
-tokio-comp = ["redis/tokio-comp"]
-async-std-comp = ["redis/async-std-comp"]
+with-tokio = ["redis/tokio-comp"]
+with-async-std = ["redis/async-std-comp"]

--- a/redis/README.md
+++ b/redis/README.md
@@ -11,6 +11,8 @@ manager for [`redis`](https://crates.io/crates/redis).
 | Feature | Description | Extra dependencies | Default |
 | ------- | ----------- | ------------------ | ------- |
 | `config` | Enable support for [config](https://crates.io/crates/config) crate | `config`, `serde/derive` | yes |
+| `tokio-comp` | [redis](https://crates.io/crates/redis) will use [`tokio`](https://crates.io/crates/tokio) runtime for AIO | `tokio` | yes |
+| `async-std-comp` | [redis](https://crates.io/crates/redis) will use [`async-std`](https://crates.io/crates/async-std) runtime for AIO | `async-std` | no |
 
 ## Example
 

--- a/redis/README.md
+++ b/redis/README.md
@@ -11,8 +11,8 @@ manager for [`redis`](https://crates.io/crates/redis).
 | Feature | Description | Extra dependencies | Default |
 | ------- | ----------- | ------------------ | ------- |
 | `config` | Enable support for [config](https://crates.io/crates/config) crate | `config`, `serde/derive` | yes |
-| `tokio-comp` | [redis](https://crates.io/crates/redis) will use [`tokio`](https://crates.io/crates/tokio) runtime for AIO | `tokio` | yes |
-| `async-std-comp` | [redis](https://crates.io/crates/redis) will use [`async-std`](https://crates.io/crates/async-std) runtime for AIO | `async-std` | no |
+| `with-tokio` | [redis](https://crates.io/crates/redis) will use [`tokio`](https://crates.io/crates/tokio) runtime for AIO | `tokio` | yes |
+| `with-async-std` | [redis](https://crates.io/crates/redis) will use [`async-std`](https://crates.io/crates/async-std) runtime for AIO | `async-std` | no |
 
 ## Example
 

--- a/redis/src/lib.rs
+++ b/redis/src/lib.rs
@@ -11,6 +11,8 @@
 //! | Feature | Description | Extra dependencies | Default |
 //! | ------- | ----------- | ------------------ | ------- |
 //! | `config` | Enable support for [config](https://crates.io/crates/config) crate | `config`, `serde/derive` | yes |
+//! | `with-tokio` | [redis](https://crates.io/crates/redis) will use [`tokio`](https://crates.io/crates/tokio) runtime for AIO | `tokio` | yes |
+//! | `with-async-std` | [redis](https://crates.io/crates/redis) will use [`async-std`](https://crates.io/crates/async-std) runtime for AIO | `async-std` | no |
 //!
 //! ## Example
 //!

--- a/test-build.sh
+++ b/test-build.sh
@@ -20,7 +20,7 @@ cargo build --no-default-features --features managed,unmanaged
 (
 	cd redis
 	cargo build
-	cargo build --no-default-features --features async-std-comp
+	cargo build --no-default-features --features with-async-std
 )
 
 (

--- a/test-build.sh
+++ b/test-build.sh
@@ -20,7 +20,7 @@ cargo build --no-default-features --features managed,unmanaged
 (
 	cd redis
 	cargo build
-	cargo build --no-default-features
+	cargo build --no-default-features --features async-std-comp
 )
 
 (


### PR DESCRIPTION
At the moment `deadpool-redis` imports `redis` with all default features enabled, and there a a lot of those:
1. With `default-features = false` its 25 dependencies and 20s compilation time.
2. With all default features enabled its 72 dependencies and 42s compilation time.

End users usually won't need all of the features, and should explicitly opt-in to use those they need. 

The only feature that `deadpool-redis` requires is `aio`, and `aio` requires async runtime. `redis` provides support for `tokio`, that can be enabled with `tokio-comp` feature, and `async-std` that can be enabled with `async-std-comp` feature. Both `tokio-comp` and `async-std-comp` features are default hence enabled in `deadpool-redis` right now.

In this PR i've made `tokio-comp` default one, since it is much more common atm. Other option might be making both `tokio-comp` and `async-std-comp` default.

This change can be considered kinda BC-ish. 
