### PR TITLE
Update redis dependency to v0.17

### DIFF
--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -17,7 +17,7 @@ deadpool = { path = "../", version = "0.5.0", default-features = false, features
 async-trait = "0.1.17"
 futures = { version = "0.3.1", features = ["compat" ] }
 log = "0.4"
-redis = "0.16.0"
+redis = "0.17"
 # only required when using the config feature
 config-crate = { package = "config", version = "0.10.1", default-features = false, optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true}


### PR DESCRIPTION
No reason not to be on the latest redis version.