### PR TITLE
Provide AsRef<T> / AsMut<T> impls for Object

### DIFF
--- a/src/managed/mod.rs
+++ b/src/managed/mod.rs
@@ -149,6 +149,18 @@ impl<T, E> DerefMut for Object<T, E> {
     }
 }
 
+impl<T, E> AsRef<T> for Object<T, E> {
+    fn as_ref(&self) -> &T {
+        self
+    }
+}
+
+impl<T, E> AsMut<T> for Object<T, E> {
+    fn as_mut(&mut self) -> &mut T {
+        self
+    }
+}
+
 struct PoolInner<T, E> {
     manager: Box<dyn Manager<T, E> + Sync + Send>,
     queue: ArrayQueue<T>,

--- a/src/unmanaged/mod.rs
+++ b/src/unmanaged/mod.rs
@@ -87,6 +87,18 @@ impl<T> DerefMut for Object<T> {
     }
 }
 
+impl<T> AsRef<T> for Object<T> {
+    fn as_ref(&self) -> &T {
+        self
+    }
+}
+
+impl<T> AsMut<T> for Object<T> {
+    fn as_mut(&mut self) -> &mut T {
+        self
+    }
+}
+
 struct PoolInner<T> {
     queue: ArrayQueue<T>,
     max_size: usize,


### PR DESCRIPTION
It is usually preferable to use an AsRef bound for generic parameters,
as it is more general than Deref. Since Object is already Deref /
DerefMut, we can trivially provide corresponding AsRef / AsMut impls.
