### PR TITLE
Add a simple actix-web + deadpool-redis example

### DIFF
--- a/examples/redis-actix-web/.gitignore
+++ b/examples/redis-actix-web/.gitignore
@@ -1,0 +1,4 @@
+/target
+**/*.rs.bk
+Cargo.lock
+.env

--- a/examples/redis-actix-web/Cargo.toml
+++ b/examples/redis-actix-web/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "deadpool-example-redis-actix-web"
+version = "0.1.0"
+authors = ["Tomas Hromada <tomas@hey.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+actix-web = "3.2.0"
+deadpool-redis = "0.6.1"
+redis = "0.17.0"

--- a/examples/redis-actix-web/README.md
+++ b/examples/redis-actix-web/README.md
@@ -1,0 +1,10 @@
+# deadpool-redis + actix-web example
+
+This example combines `deadpool-redis` with a `actix-web` webservice to
+implement a simple API service that responds to a PING Redis query.
+
+## Configuration options
+
+The code assumes that your current user can access Redis running at redis://127.0.0.1:6379.
+You can override the Redis connection url by setting the `REDIS_URL` ENV variable.
+For more configuration options see `deadpool_redis::Config`.

--- a/examples/redis-actix-web/src/main.rs
+++ b/examples/redis-actix-web/src/main.rs
@@ -1,0 +1,43 @@
+use actix_web::{error, get, middleware, web, App, HttpServer, HttpResponse, Error};
+use deadpool_redis::{cmd, Connection, Pool, PoolError, Config as RedisConfig};
+use std::env;
+
+
+fn redis_uri() -> String {
+    match env::var("REDIS_URL") {
+        Ok(s) if !s.is_empty() => s,
+        _ => String::from(String::from("redis://127.0.0.1:6379"))
+    }
+}
+
+async fn redis_ping(pool: &Pool) -> Result<String, PoolError> {
+    let mut connection: Connection = pool.get().await?;
+    let pong: String = cmd("PING").query_async(&mut connection).await?;
+
+    Ok(pong)
+}
+
+#[get("/")]
+async fn index(redis_pool: web::Data<Pool>) -> Result<HttpResponse, Error> {
+    let pong = redis_ping(&redis_pool).await.or_else(|pool_error| Err(error::ErrorNotAcceptable(format!("{}", pool_error))))?;
+
+    Ok(HttpResponse::Ok().body(format!("Redis PING -> {}", pong)))
+}
+
+#[actix_web::main]
+async fn main() -> std::io::Result<()> {
+    let redis_config = RedisConfig { url: Some(redis_uri()), pool: None };
+    let redis_pool = redis_config.create_pool().unwrap();
+    let server_url = "127.0.0.1:8080";
+
+    let server = HttpServer::new(move || {
+        App::new()
+            .data(redis_pool.clone())
+            .wrap(middleware::Logger::default())
+            .service(index)
+    }).bind(server_url)?.run();
+
+    println!("Server running! Access the index page here: http://{}/", server_url);
+
+    server.await
+}


### PR DESCRIPTION
Hi, this PR adds a simple example of using `actix-web` + `deadpool-redis` together. I intentionally didn't include the config+env setup you have elsewhere, because 
- you already have it in the actix-web postgres example;
- I wanted to keep this example as simple as possible;
- the redis deployment I use expects `REDIS_URL`, and I wanted that to be explicit here as well.

Hope that's fine! Let me know if you'd like me to update the example. 

Thanks! Tomas