### PR TITLE
Make tokio an optional dependency for core module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ async-trait = { version = "0.1.17", optional = true }
 config-crate = { package = "config", version = "0.11", default-features = false, optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 # async runtimes
-tokio = { version = "1", features = ["sync"] }
+tokio = { version = "1", features = ["sync"], optional = true }
 async-std = { version = "1", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
At the moment, tokio is a required dependency even if we are using async-std. This patch make it optional to clean up dependency tree.