### PR TITLE
Export CreatePoolError from deadpool-redis

### DIFF
--- a/redis/src/config.rs
+++ b/redis/src/config.rs
@@ -125,9 +125,12 @@ impl redis::IntoConnectionInfo for ConnectionInfo {
     }
 }
 
+/// An error returned when pool creation fails.
 #[derive(Debug)]
 pub enum CreatePoolError {
+    /// The pool configuration contained invalid options.
     Config(String),
+    /// Redis returned an error while creating the pool.
     Redis(redis::RedisError),
 }
 

--- a/redis/src/lib.rs
+++ b/redis/src/lib.rs
@@ -141,7 +141,7 @@ type RecycleResult = deadpool::managed::RecycleResult<RedisError>;
 pub use redis;
 
 mod config;
-pub use config::Config;
+pub use config::{Config, CreatePoolError};
 
 /// A wrapper for `redis::Connection`. The `query_async` and `execute_async`
 /// functions of `redis::Cmd` and `redis::Pipeline` consume the connection.


### PR DESCRIPTION
This type is currently not exported from the crate, making it difficult to use without wrapping in something like `anyhow`.