### PR TITLE
Added a constructor for the redis config that only uses the url

### DIFF
--- a/redis/src/config.rs
+++ b/redis/src/config.rs
@@ -217,6 +217,15 @@ impl Config {
     pub fn get_pool_config(&self) -> PoolConfig {
         self.pool.clone().unwrap_or_default()
     }
+
+    /// Create the `Config` from a redis URL (like redis://127.0.0.1)
+    pub fn from_url<T: Into<String>>(url: T) -> Config {
+        Config {
+            url: Some(url.into()),
+            connection: None,
+            pool: None,
+        }
+    }
 }
 
 impl Default for Config {


### PR DESCRIPTION
This makes creating the config slightly easier if you only want to use a
URL. This is because either the url or the connection field should be
`Some`. Otherwise you would have to create the struct yourself, by
setting all fields; or using the default implementation which requires
you to set the connection field to None.