### PR TITLE
Give the `interact` closure a mutable reference

### DIFF
--- a/src/managed/sync.rs
+++ b/src/managed/sync.rs
@@ -105,14 +105,14 @@ where
     /// is not blocked.
     pub async fn interact<F, R>(&self, f: F) -> Result<R, InteractError<E>>
     where
-        F: FnOnce(&T) -> Result<R, E> + Send + 'static,
+        F: FnOnce(&mut T) -> Result<R, E> + Send + 'static,
         R: Send + 'static,
     {
         let arc = self.obj.clone();
         self.runtime
             .spawn_blocking(move || {
-                let guard = arc.lock().unwrap();
-                let conn = guard.as_ref().unwrap();
+                let mut guard = arc.lock().unwrap();
+                let conn = guard.as_mut().unwrap();
                 f(conn)
             })
             .await


### PR DESCRIPTION
The major upcoming Diesel release (no ETA yet, I think) will require a mutable connection to interact with the database: https://github.com/diesel-rs/diesel/commit/75c688c3b246295f6f7182e0fec1b58cc685b4ed

As far as I can tell, the change proposed here shouldn't break existing consumers of `deadpool`.