### PR TITLE
Add SyncGuard for direct access to the inner object of SyncWrapper

### DIFF
--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -36,7 +36,7 @@ pub mod sqlite;
 use deadpool::managed;
 
 pub use deadpool::{
-    managed::{Pool, PoolConfig, Timeouts},
+    managed::{sync::SyncGuard, Pool, PoolConfig, Timeouts},
     Runtime,
 };
 

--- a/tests/managed_sync.rs
+++ b/tests/managed_sync.rs
@@ -1,0 +1,44 @@
+#![cfg(feature = "managed")]
+
+use async_trait::async_trait;
+
+use deadpool::{
+    managed::{sync::SyncWrapper, Manager, Pool, RecycleResult},
+    Runtime,
+};
+
+struct Computer {
+    pub answer: usize,
+}
+
+struct ComputerManager {}
+
+#[async_trait]
+impl Manager for ComputerManager {
+    type Type = SyncWrapper<Computer, ()>;
+    type Error = ();
+
+    async fn create(&self) -> Result<Self::Type, Self::Error> {
+        SyncWrapper::new(Runtime::Tokio1, || Ok(Computer { answer: 42 })).await
+    }
+
+    async fn recycle(&self, _: &mut Self::Type) -> RecycleResult<Self::Error> {
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn post_recycle() {
+    let manager = ComputerManager {};
+    let pool = Pool::<ComputerManager>::builder(manager)
+        .max_size(1)
+        .build()
+        .unwrap();
+    let obj = pool.get().await.unwrap();
+    assert_eq!(
+        obj.interact(|computer| Ok(computer.answer)).await.unwrap(),
+        42
+    );
+    let guard = obj.lock().unwrap();
+    assert_eq!(guard.answer, 42);
+}


### PR DESCRIPTION
@dchenk what do you think of this instead of #135 

Maybe `lock`/`try_lock` is a bit misleading? Though it makes it pretty explicit what's happening under the hood... :thinking: 