### PR TITLE
Make SyncGuard public

### DIFF
--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -36,7 +36,7 @@ pub mod sqlite;
 use deadpool::managed;
 
 pub use deadpool::{
-    managed::{Pool, PoolConfig, Timeouts},
+    managed::{sync::SyncGuard, Pool, PoolConfig, Timeouts},
     Runtime,
 };
 


### PR DESCRIPTION
With the `SyncGuard` type private, it was a bit awkward to express the return type of `SyncWrapper::lock`.