### PR TITLE
add the deadpool and deadpool_sync for postgres and mysql

### DIFF
--- a/diesel/CHANGELOG.md
+++ b/diesel/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## v0.3.1
+* Expose the reexports from deadpool and deadpool_sync for mysql and postgres
+
 ## v0.3.0
 
 * __Breaking:__ Replace `deadpool::managed::sync` by

--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deadpool-diesel"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2018"
 resolver = "2"
 authors = ["Michael P. Jung <michael.jung@terreon.de>"]
@@ -31,4 +31,3 @@ diesel = { version = "1.4.7", default-features = false }
 [dev-dependencies]
 diesel = { version = "1.4.3", features = ["sqlite"] }
 tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread"] }
-

--- a/diesel/src/mysql.rs
+++ b/diesel/src/mysql.rs
@@ -3,6 +3,8 @@
 /// Manager for MySQL connections
 pub type Manager = crate::Manager<diesel::MysqlConnection>;
 
+pub use deadpool::managed::reexports::*;
+pub use deadpool_sync::reexports::*;
 deadpool::managed_reexports!(
     "diesel",
     Manager,

--- a/diesel/src/postgres.rs
+++ b/diesel/src/postgres.rs
@@ -3,6 +3,8 @@
 /// Manager for PostgreSQL connections
 pub type Manager = crate::Manager<diesel::PgConnection>;
 
+pub use deadpool::managed::reexports::*;
+pub use deadpool_sync::reexports::*;
 deadpool::managed_reexports!(
     "diesel",
     Manager,


### PR DESCRIPTION
When integrating deadpool-diesel into a project the examples use sqlite and pull in the Runtime from the deadpool_diesel::sqlite module.    However as I am using postgres in my app the deadpool_diesel::postgres module does not re-export those.

so this PR re-exports those for the mysql and postgres modules.  

the alternative (breaking change) would be to not export them from the DB specific modules and only re-export them from deadpool_diesel (which is being done already).

Let me know which you'd prefer and I can update this PR if needed.