### PR TITLE
implement Serialize too when serde is enabled

### DIFF
--- a/examples/postgres-benchmark/src/main.rs
+++ b/examples/postgres-benchmark/src/main.rs
@@ -2,13 +2,13 @@ use std::time::{Duration, Instant};
 
 use deadpool_postgres::Runtime;
 use dotenv::dotenv;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc;
 
 const WORKERS: usize = 16;
 const ITERATIONS: usize = 1000;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 struct Config {
     #[serde(default)]
     pg: deadpool_postgres::Config,

--- a/lapin/src/config.rs
+++ b/lapin/src/config.rs
@@ -37,7 +37,7 @@ use crate::{CreatePoolError, Manager, Pool, PoolBuilder, PoolConfig, Runtime};
 /// }
 /// ```
 #[derive(Clone, Debug, Default)]
-#[cfg_attr(feature = "serde", derive(serde_1::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde_1::Deserialize, serde_1::Serialize))]
 #[cfg_attr(feature = "serde", serde(crate = "serde_1"))]
 pub struct Config {
     /// AMQP server URL.

--- a/postgres/src/config.rs
+++ b/postgres/src/config.rs
@@ -35,7 +35,7 @@ use super::{Pool, PoolConfig};
 /// ```rust
 /// # use serde_1 as serde;
 /// #
-/// #[derive(serde::Deserialize)]
+/// #[derive(serde::Deserialize, serde::Serialize)]
 /// # #[serde(crate = "serde_1")]
 /// struct Config {
 ///     pg: deadpool_postgres::Config,
@@ -49,7 +49,7 @@ use super::{Pool, PoolConfig};
 /// }
 /// ```
 #[derive(Clone, Debug, Default)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "serde", serde(crate = "serde_1"))]
 pub struct Config {
     /// See [`tokio_postgres::Config::user`].
@@ -269,7 +269,7 @@ impl Config {
 /// [`Fast`]: RecyclingMethod::Fast
 /// [`Verified`]: RecyclingMethod::Verified
 #[derive(Clone, Debug, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "serde", serde(crate = "serde_1"))]
 pub enum RecyclingMethod {
     /// Only run [`Client::is_closed()`][1] when recycling existing connections.
@@ -351,7 +351,7 @@ impl RecyclingMethod {
 ///
 /// [`Manager`]: super::Manager
 #[derive(Clone, Debug, Default)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "serde", serde(crate = "serde_1"))]
 pub struct ManagerConfig {
     /// Method of how a connection is recycled. See [`RecyclingMethod`].
@@ -364,7 +364,7 @@ pub struct ManagerConfig {
 /// This is duplicated here in order to add support for the
 /// [`serde::Deserialize`] trait which is required for the [`serde`] support.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "serde", serde(crate = "serde_1"))]
 #[non_exhaustive]
 pub enum TargetSessionAttrs {
@@ -390,7 +390,7 @@ impl From<TargetSessionAttrs> for PgTargetSessionAttrs {
 /// This is duplicated here in order to add support for the
 /// [`serde::Deserialize`] trait which is required for the [`serde`] support.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "serde", serde(crate = "serde_1"))]
 #[non_exhaustive]
 pub enum SslMode {
@@ -420,7 +420,7 @@ impl From<SslMode> for PgSslMode {
 /// This is duplicated here in order to add support for the
 /// [`serde::Deserialize`] trait which is required for the [`serde`] support.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "serde", serde(crate = "serde_1"))]
 #[non_exhaustive]
 pub enum ChannelBinding {

--- a/postgres/tests/postgres.rs
+++ b/postgres/tests/postgres.rs
@@ -1,12 +1,12 @@
 use std::{collections::HashMap, env, time::Duration};
 
 use futures::future;
-use serde_1::Deserialize;
+use serde_1::{Deserialize, Serialize};
 use tokio_postgres::{types::Type, IsolationLevel};
 
 use deadpool_postgres::{ManagerConfig, Pool, RecyclingMethod, Runtime};
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(crate = "serde_1")]
 struct Config {
     #[serde(default)]

--- a/redis/src/config.rs
+++ b/redis/src/config.rs
@@ -2,7 +2,7 @@ use std::{fmt, path::PathBuf};
 
 use redis::RedisError;
 #[cfg(feature = "serde")]
-use serde_1::Deserialize;
+use serde_1::{Deserialize, Serialize};
 
 use crate::{CreatePoolError, Pool, PoolBuilder, PoolConfig, RedisResult, Runtime};
 
@@ -36,7 +36,7 @@ use crate::{CreatePoolError, Pool, PoolBuilder, PoolConfig, RedisResult, Runtime
 /// }
 /// ```
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "serde", derive(serde_1::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde_1::Deserialize, serde_1::Serialize))]
 #[cfg_attr(feature = "serde", serde(crate = "serde_1"))]
 pub struct Config {
     /// Redis URL.
@@ -114,7 +114,7 @@ impl Default for Config {
 /// This is duplicated here in order to add support for the
 /// [`serde::Deserialize`] trait which is required for the [`serde`] support.
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "serde", derive(Deserialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[cfg_attr(feature = "serde", serde(crate = "serde_1"))]
 pub enum ConnectionAddr {
     /// Format for this is `(host, port)`.
@@ -189,7 +189,7 @@ impl From<redis::ConnectionAddr> for ConnectionAddr {
 /// This is duplicated here in order to add support for the
 /// [`serde::Deserialize`] trait which is required for the [`serde`] support.
 #[derive(Clone, Debug, Default)]
-#[cfg_attr(feature = "serde", derive(Deserialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[cfg_attr(feature = "serde", serde(crate = "serde_1"))]
 pub struct ConnectionInfo {
     /// A connection address for where to connect to.
@@ -228,7 +228,7 @@ impl redis::IntoConnectionInfo for ConnectionInfo {
 /// This is duplicated here in order to add support for the
 /// [`serde::Deserialize`] trait which is required for the [`serde`] support.
 #[derive(Clone, Debug, Default)]
-#[cfg_attr(feature = "serde", derive(Deserialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[cfg_attr(feature = "serde", serde(crate = "serde_1"))]
 pub struct RedisConnectionInfo {
     /// The database number to use. This is usually `0`.

--- a/redis/tests/redis.rs
+++ b/redis/tests/redis.rs
@@ -3,9 +3,9 @@
 use deadpool_redis::Runtime;
 use futures::FutureExt;
 use redis::cmd;
-use serde_1::Deserialize;
+use serde_1::{Deserialize, Serialize};
 
-#[derive(Debug, Default, Deserialize)]
+#[derive(Debug, Default, Deserialize, Serialize)]
 #[serde(crate = "serde_1")]
 struct Config {
     #[serde(default)]

--- a/sqlite/src/config.rs
+++ b/sqlite/src/config.rs
@@ -17,7 +17,7 @@ use crate::{CreatePoolError, Manager, Pool, PoolBuilder, PoolConfig, Runtime};
 /// ```rust
 /// # use serde_1 as serde;
 /// #
-/// #[derive(serde::Deserialize)]
+/// #[derive(serde::Deserialize, serde::Serialize)]
 /// # #[serde(crate = "serde_1")]
 /// struct Config {
 ///     sqlite: deadpool_sqlite::Config,
@@ -31,7 +31,7 @@ use crate::{CreatePoolError, Manager, Pool, PoolBuilder, PoolConfig, Runtime};
 /// }
 /// ```
 #[derive(Clone, Debug, Default)]
-#[cfg_attr(feature = "serde", derive(serde_1::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde_1::Deserialize, serde_1::Serialize))]
 #[cfg_attr(feature = "serde", serde(crate = "serde_1"))]
 pub struct Config {
     /// Path to SQLite database file.

--- a/src/managed/config.rs
+++ b/src/managed/config.rs
@@ -6,7 +6,7 @@ use super::BuildError;
 ///
 /// [`Pool`]: super::Pool
 #[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct PoolConfig {
     /// Maximum size of the [`Pool`].
     ///
@@ -45,7 +45,7 @@ impl Default for PoolConfig {
 /// [`Object`]: super::Object
 /// [`Pool`]: super::Pool
 #[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct Timeouts {
     /// Timeout when waiting for a slot to become available.
     pub wait: Option<Duration>,

--- a/src/unmanaged/config.rs
+++ b/src/unmanaged/config.rs
@@ -4,7 +4,7 @@ use crate::Runtime;
 
 /// Pool configuration.
 #[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct PoolConfig {
     /// Maximum size of the pool.
     pub max_size: usize,

--- a/tests/managed_config.rs
+++ b/tests/managed_config.rs
@@ -3,7 +3,7 @@
 use std::{collections::HashMap, env, time::Duration};
 
 use config::Config;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use deadpool::managed::PoolConfig;
 
@@ -34,7 +34,7 @@ impl Drop for Env {
     }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 struct TestConfig {
     pool: PoolConfig,
 }


### PR DESCRIPTION
I don't know what you'll think of this, but I needed to serialize the configuration (to generate a long complex default configuration file with proper syntax). I suppose few other people will also want that, so maybe your not interested, or maybe it could be feature gated under another feature.  This PR adds serialization to the 'serde' feature.
