### PR TITLE
Export `TargetSessionAttrs` and `ChannelBinding`

### DIFF
--- a/postgres/CHANGELOG.md
+++ b/postgres/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## Unreleased
+
+* Export `TargetSessionAttrs` and `ChannelBinding` enums (part of `Config`
+  struct)
+
 ## v0.10.1
 
 * Config structs now implement `Serialize`

--- a/postgres/src/lib.rs
+++ b/postgres/src/lib.rs
@@ -42,7 +42,10 @@ use tokio_postgres::{
 
 pub use tokio_postgres;
 
-pub use self::config::{Config, ConfigError, ManagerConfig, RecyclingMethod, SslMode};
+pub use self::config::{
+    ChannelBinding, Config, ConfigError, ManagerConfig, RecyclingMethod, SslMode,
+    TargetSessionAttrs,
+};
 
 pub use deadpool::managed::reexports::*;
 deadpool::managed_reexports!(


### PR DESCRIPTION
Correct me if I'm wrong, but I believe it's not possible to set these options without the library explicitly exporting these.

I've gone with exporting them under the root crate since that's where `SslMode` was already exported. It might not be a terrible option to export them under `crate::config::*` either though.