### PR TITLE
feat: split Status.available counter

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,8 +44,9 @@ pub struct Status {
     /// The current size of the pool.
     pub size: usize,
 
-    /// The number of available objects in the pool. If there are no
-    /// objects in the pool this number can become negative and stores the
-    /// number of futures waiting for an object.
-    pub available: isize,
+    /// The number of available objects in the pool.
+    pub available: usize,
+
+    /// The number of futures waiting for an object.
+    pub waiting: usize,
 }

--- a/tests/managed_deadlock.rs
+++ b/tests/managed_deadlock.rs
@@ -87,20 +87,23 @@ async fn pool_drained() {
     let get_1 = tokio::spawn(async move { pool_clone.get().await });
     task::yield_now().await;
     assert_eq!(pool.status().size, 0);
-    assert_eq!(pool.status().available, -1);
+    assert_eq!(pool.status().available, 0);
+    assert_eq!(pool.status().waiting, 1);
 
     // let second task wait for the connection
     let pool_clone = pool.clone();
     let get_2 = tokio::spawn(async move { pool_clone.get().await });
     task::yield_now().await;
     assert_eq!(pool.status().size, 0);
-    assert_eq!(pool.status().available, -2);
+    assert_eq!(pool.status().available, 0);
+    assert_eq!(pool.status().waiting, 2);
 
     // first task receives an error
     rc.create_err();
     assert!(get_1.await.unwrap().is_err());
     assert_eq!(pool.status().size, 0);
-    assert_eq!(pool.status().available, -1);
+    assert_eq!(pool.status().available, 0);
+    assert_eq!(pool.status().waiting, 1);
 
     // the second task should now be able to create an object
     rc.create_ok();


### PR DESCRIPTION
Fixes #199.

The _available_ counter in the Status struct could also represent the number of futures waiting for an object, this could cause some confusion (see #191.)

This PR splits that counter into two: _available_ and _waiting_, for this it also changes the InnerPool to track the number of users instead of the number of available objects, as in 7ffa964.