### PR TITLE
Make `Transaction`'s `statement_cache` pub

### DIFF
--- a/postgres/src/lib.rs
+++ b/postgres/src/lib.rs
@@ -440,7 +440,7 @@ pub struct Transaction<'a> {
     txn: PgTransaction<'a>,
 
     /// [`StatementCache`] of this [`Transaction`].
-    statement_cache: Arc<StatementCache>,
+    pub statement_cache: Arc<StatementCache>,
 }
 
 impl<'a> Transaction<'a> {


### PR DESCRIPTION
In the presence of changing schemas, I am hitting `cached plan must not change result type` errors in in extremely rare cases. I would like to be able to invalidate the cache and try again with just the reference to the transaction, where I don't have a handle to the `Pool` which handed out the `Transaction`. 

`statement_cache` is already pub for `ClientWrapper` and `Manager`.