### PR TITLE
Fix Diesel recycling error handling

### DIFF
--- a/diesel/src/manager.rs
+++ b/diesel/src/manager.rs
@@ -74,6 +74,7 @@ where
         obj.interact(|conn| CheckConnectionQuery.execute(conn).map_err(Error::Ping))
             .await
             .map_err(|e| RecycleError::Message(format!("Panic: {:?}", e)))
+            .and_then(|r| r.map_err(RecycleError::Backend))
             .map(|_| ())
     }
 }


### PR DESCRIPTION
I noticed that when DB connection was broken the pool didn't catch that.
This change fixes the problem.