### PR TITLE
Implement UnwindSafe by never returning on panic

### DIFF
--- a/src/managed/mod.rs
+++ b/src/managed/mod.rs
@@ -71,6 +71,7 @@ use std::{
     future::Future,
     marker::PhantomData,
     ops::{Deref, DerefMut},
+    panic::{RefUnwindSafe, UnwindSafe},
     sync::{
         atomic::{AtomicUsize, Ordering},
         Arc, Mutex, Weak,
@@ -613,6 +614,20 @@ impl<M: Manager, W: From<Object<M>>> Pool<M, W> {
     pub fn manager(&self) -> &M {
         &self.inner.manager
     }
+}
+
+impl<M: Manager, W: From<Object<M>>> UnwindSafe for Pool<M, W>
+where
+    M: UnwindSafe,
+    W: UnwindSafe,
+{
+}
+
+impl<M: Manager, W: From<Object<M>>> RefUnwindSafe for Pool<M, W>
+where
+    M: UnwindSafe,
+    W: UnwindSafe,
+{
 }
 
 struct PoolInner<M: Manager> {

--- a/src/unmanaged/mod.rs
+++ b/src/unmanaged/mod.rs
@@ -78,6 +78,13 @@ impl<T> Object<T> {
 
 impl<T> Drop for Object<T> {
     fn drop(&mut self) {
+        // If we're panicking, there is no way to determine whether the object
+        // we are dropping is the source of the panic. Therefore, always discard
+        // the object on a panic, and do not return it to the pool.
+        if std::thread::panicking() {
+            return;
+        }
+
         if let Some(obj) = self.obj.take() {
             if let Some(pool) = self.pool.upgrade() {
                 {


### PR DESCRIPTION
Don't return objects to the pool on panic, since we can't be sure whether they were the source of the panic.

See-also: #139