### PR TITLE
[deadpool-redis] Bump `redis` to v0.23

### DIFF
--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -24,7 +24,7 @@ serde = ["deadpool/serde", "serde_1"]
 deadpool = { path = "../", version = "0.9.0", default-features = false, features = [
     "managed",
 ] }
-redis = { version = "0.22", default-features = false, features = ["aio"] }
+redis = { version = "0.23", default-features = false, features = ["aio"] }
 serde_1 = { package = "serde", version = "1.0", features = [
     "derive",
 ], optional = true }
@@ -33,7 +33,7 @@ serde_1 = { package = "serde", version = "1.0", features = [
 config = { version = "0.13", features = ["json"] }
 dotenv = "0.15.0"
 futures = "0.3.15"
-redis = { version = "0.22", default-features = false, features = [
+redis = { version = "0.23", default-features = false, features = [
     "tokio-comp",
 ] }
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }


### PR DESCRIPTION
Bumps the `redis` version to the newly released v0.23