### PR TITLE
Add pool config option for fifo/lifo queue mode

### DIFF
--- a/src/managed/builder.rs
+++ b/src/managed/builder.rs
@@ -4,7 +4,7 @@ use crate::Runtime;
 
 use super::{
     hooks::{Hook, Hooks},
-    Manager, Object, Pool, PoolConfig, Timeouts,
+    Manager, Object, Pool, PoolConfig, QueueMode, Timeouts,
 };
 
 /// Possible errors returned when [`PoolBuilder::build()`] fails to build a
@@ -130,6 +130,12 @@ where
     /// Sets the [`Timeouts::recycle`] value of the [`PoolConfig::timeouts`].
     pub fn recycle_timeout(mut self, value: Option<Duration>) -> Self {
         self.config.timeouts.recycle = value;
+        self
+    }
+
+    /// Sets the [`PoolConfig::queue_mode`].
+    pub fn queue_mode(mut self, value: QueueMode) -> Self {
+        self.config.queue_mode = value;
         self
     }
 

--- a/src/managed/config.rs
+++ b/src/managed/config.rs
@@ -18,6 +18,14 @@ pub struct PoolConfig {
     /// [`Pool`]: super::Pool
     #[cfg_attr(feature = "serde", serde(default))]
     pub timeouts: Timeouts,
+
+    /// Queue mode of the [`Pool`].
+    ///
+    /// Determines the order of objects being queued and dequeued.
+    ///
+    /// [`Pool`]: super::Pool
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub queue_mode: QueueMode,
 }
 
 impl PoolConfig {
@@ -28,6 +36,7 @@ impl PoolConfig {
         Self {
             max_size,
             timeouts: Timeouts::default(),
+            queue_mode: QueueMode::default(),
         }
     }
 }
@@ -86,6 +95,20 @@ impl Default for Timeouts {
             recycle: None,
         }
     }
+}
+
+/// Mode for dequeuing [`Object`]s from a [`Pool`].
+///
+/// [`Object`]: super::Object
+/// [`Pool`]: super::Pool
+#[derive(Clone, Copy, Debug, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+pub enum QueueMode {
+    /// Dequeue the object that was least recently added (first in first out).
+    #[default]
+    Fifo,
+    /// Dequeue the object that was most recently added (last in first out).
+    Lifo,
 }
 
 /// This error is used when building pools via the config `create_pool`

--- a/tests/managed_timeout.rs
+++ b/tests/managed_timeout.rs
@@ -51,6 +51,7 @@ async fn test_managed_timeout(runtime: Runtime) {
             wait: Some(Duration::from_millis(0)),
             recycle: Some(Duration::from_millis(0)),
         },
+        ..Default::default()
     };
     let pool = Pool::builder(mgr)
         .config(cfg)


### PR DESCRIPTION
Implements a pool config setting that allows specifying the order in which objects are dequeued from the pool.

Besides sometimes resulting in better throughput if a "warm" object can be used, this is especially useful when wanting to automatically scale down the pool over time with decreasing usage: If the pool operates in LIFO mode, an average utilization smaller than the pool size will automatically result in some objects being recycled more often than others, allowing a sweeper process to remove the least frequently used objects.

This seems(?) to be a breaking change considering that all fields on `PoolConfig` are `pub` (see for example the `tests/managed_timeout.rs` which had to be fixed), so happy to receive guidance for how to extend the pool options without breaking anyone who might be constructing `PoolConfig` directly or exhaustively matching it. Alternatively, we could consider adding a set of methods to the pool for LIFO (e.g. `get_lifo`) but that seems somewhat less ergonomic to me.