### PR TITLE
Remove useless pattern matching

### DIFF
--- a/sync/src/lib.rs
+++ b/sync/src/lib.rs
@@ -121,9 +121,7 @@ where
                 f(conn)
             })
             .await
-            .map_err(|e| match e {
-                SpawnBlockingError::Panic(p) => InteractError::Panic(p),
-            })
+            .map_err(|SpawnBlockingError::Panic(e)| InteractError::Panic(p))
     }
 
     /// Indicates whether the underlying [`Mutex`] has been poisoned.


### PR DESCRIPTION
This patten matching was used to unpack some struct, this can be done as the function parameter.