### PR TITLE
Bound GenericClient with Sync to allow extension traits

### DIFF
--- a/postgres/src/generic_client.rs
+++ b/postgres/src/generic_client.rs
@@ -19,7 +19,7 @@ mod private {
 ///
 /// This trait is "sealed", and cannot be implemented outside of this crate.
 #[async_trait]
-pub trait GenericClient: private::Sealed {
+pub trait GenericClient: Sync + private::Sealed {
     /// Like `Client::execute`.
     async fn execute<T>(&self, query: &T, params: &[&(dyn ToSql + Sync)]) -> Result<u64, Error>
     where


### PR DESCRIPTION
I ran into a problem where I could not create an extension trait based on `GenericClient` because awaiting futures returned by the `GenericClient` methods requires that `&self` be `Sync`. Both `Transaction` and `Client` are already sync, so this just makes that requirement explicit.