### PR TITLE
Update license field following SPDX 2.1 license expression standard

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ resolver = "2"
 authors = ["Michael P. Jung <michael.jung@terreon.de>"]
 description = "Dead simple async pool"
 keywords = ["async", "database", "pool"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 repository = "https://github.com/bikeshedder/deadpool"
 readme = "README.md"
 

--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -6,7 +6,7 @@ resolver = "2"
 authors = ["Michael P. Jung <michael.jung@terreon.de>"]
 description = "Dead simple async pool for diesel"
 keywords = ["async", "database", "pool", "diesel"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 repository = "https://github.com/bikeshedder/deadpool"
 readme = "README.md"
 

--- a/lapin/Cargo.toml
+++ b/lapin/Cargo.toml
@@ -6,7 +6,7 @@ resolver = "2"
 authors = ["Michael P. Jung <michael.jung@terreon.de>"]
 description = "Dead simple async pool for lapin"
 keywords = ["async", "lapin", "pool", "amqp", "rabbitmq"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 repository = "https://github.com/bikeshedder/deadpool"
 readme = "README.md"
 

--- a/memcached/Cargo.toml
+++ b/memcached/Cargo.toml
@@ -9,7 +9,7 @@ authors = [
 ]
 description = "Dead simple async pool for memcached"
 keywords = ["async", "memcached", "pool"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 repository = "https://github.com/bikeshedder/deadpool"
 readme = "README.md"
 

--- a/postgres/Cargo.toml
+++ b/postgres/Cargo.toml
@@ -6,7 +6,7 @@ resolver = "2"
 authors = ["Michael P. Jung <michael.jung@terreon.de>"]
 description = "Dead simple async pool for tokio-postgres"
 keywords = ["async", "database", "pool", "postgres"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 repository = "https://github.com/bikeshedder/deadpool"
 readme = "README.md"
 

--- a/r2d2/Cargo.toml
+++ b/r2d2/Cargo.toml
@@ -6,7 +6,7 @@ resolver = "2"
 authors = ["Michael P. Jung <michael.jung@terreon.de>"]
 description = "Dead simple async pool for r2d2 managers"
 keywords = ["async", "database", "pool", "r2d2"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 repository = "https://github.com/bikeshedder/deadpool"
 readme = "README.md"
 

--- a/redis-cluster/Cargo.toml
+++ b/redis-cluster/Cargo.toml
@@ -6,7 +6,7 @@ resolver = "2"
 authors = ["Michael P. Jung <michael.jung@terreon.de>", "Subeom Choi <subumm1@gmail.com>"]
 description = "Dead simple async pool for redis-cluster"
 keywords = ["async", "redis-cluster", "pool"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 repository = "https://github.com/bikeshedder/deadpool"
 readme = "README.md"
 

--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -6,7 +6,7 @@ resolver = "2"
 authors = ["Michael P. Jung <michael.jung@terreon.de>"]
 description = "Dead simple async pool for redis"
 keywords = ["async", "redis", "pool"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 repository = "https://github.com/bikeshedder/deadpool"
 readme = "README.md"
 

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -6,7 +6,7 @@ resolver = "2"
 authors = ["Michael P. Jung <michael.jung@terreon.de>"]
 description = "Dead simple async pool utitities for sync managers"
 keywords = ["async", "database", "pool", "sync", "utils"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 repository = "https://github.com/bikeshedder/deadpool"
 readme = "README.md"
 

--- a/sqlite/Cargo.toml
+++ b/sqlite/Cargo.toml
@@ -6,7 +6,7 @@ resolver = "2"
 authors = ["Michael P. Jung <michael.jung@terreon.de>"]
 description = "Dead simple async pool for rusqlite"
 keywords = ["async", "database", "pool", "sqlite"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 repository = "https://github.com/bikeshedder/deadpool"
 readme = "README.md"
 

--- a/sync/Cargo.toml
+++ b/sync/Cargo.toml
@@ -6,7 +6,7 @@ resolver = "2"
 authors = ["Michael P. Jung <michael.jung@terreon.de>"]
 description = "Dead simple async pool utitities for sync managers"
 keywords = ["async", "database", "pool", "sync", "utils"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 repository = "https://github.com/bikeshedder/deadpool"
 readme = "README.md"
 


### PR DESCRIPTION
The new recommendation is to follow the SPDX 2.1 standard. This allows automatic license verification software to work properly. Reference: https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields