### PR TITLE
Allow to customize the recycle check function used in deadpool_diesel

### DIFF
--- a/diesel/CHANGELOG.md
+++ b/diesel/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Update `deadpool` dependency to version `0.10`
 * Add `tracing` feature
+* Check for open transactions before recycling connections
+* Allow to configure a custom recycle check function to customize ping queries for different database backends
 
 ## v0.4.1
 

--- a/diesel/src/error.rs
+++ b/diesel/src/error.rs
@@ -12,6 +12,11 @@ pub enum Error {
 
     /// Failed to ping the database.
     Ping(diesel::result::Error),
+
+    /// The transaction manager of a given
+    /// connection is in a broken state. That usually
+    /// means that it contains an open uncommited transaction
+    BrokenTransactionManger,
 }
 
 impl fmt::Display for Error {
@@ -19,6 +24,7 @@ impl fmt::Display for Error {
         match self {
             Self::Connection(e) => write!(f, "Failed to establish connection: {}", e),
             Self::Ping(e) => write!(f, "Failed to ping database: {}", e),
+            Self::BrokenTransactionManger => write!(f, "Broken transaction manager"),
         }
     }
 }
@@ -28,6 +34,7 @@ impl std::error::Error for Error {
         match self {
             Self::Connection(e) => Some(e),
             Self::Ping(e) => Some(e),
+            Self::BrokenTransactionManger => None,
         }
     }
 }

--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -43,7 +43,7 @@ pub use deadpool_sync::reexports::*;
 // generic itself.
 pub use deadpool::managed::Pool;
 
-pub use self::{error::Error, manager::Manager};
+pub use self::{error::Error, manager::{Manager, ManagerConfig, RecycleCheckCallback, RecyclingMethod}};
 
 /// Type alias for using [`deadpool::managed::PoolError`] with [`diesel`].
 pub type PoolError = managed::PoolError<Error>;

--- a/diesel/src/lib.rs
+++ b/diesel/src/lib.rs
@@ -43,7 +43,10 @@ pub use deadpool_sync::reexports::*;
 // generic itself.
 pub use deadpool::managed::Pool;
 
-pub use self::{error::Error, manager::{Manager, ManagerConfig, RecycleCheckCallback, RecyclingMethod}};
+pub use self::{
+    error::Error,
+    manager::{Manager, ManagerConfig, RecycleCheckCallback, RecyclingMethod},
+};
 
 /// Type alias for using [`deadpool::managed::PoolError`] with [`diesel`].
 pub type PoolError = managed::PoolError<Error>;

--- a/diesel/src/manager.rs
+++ b/diesel/src/manager.rs
@@ -15,6 +15,7 @@ use crate::Error;
 /// See the [`deadpool` documentation](deadpool) for usage examples.
 ///
 /// [`Manager`]: managed::Manager
+/// [`Connection`]: crate::Connection
 pub struct Manager<C> {
     database_url: String,
     runtime: Runtime,
@@ -51,6 +52,8 @@ pub enum RecyclingMethod<C> {
 ///
 /// This currently only makes it possible to specify which [`RecyclingMethod`]
 /// should be used when retrieving existing objects from the [`Pool`].
+///
+/// [`Pool`]: crate::Pool
 #[derive(Debug)]
 pub struct ManagerConfig<C> {
     /// Method of how a connection is recycled. See [RecyclingMethod].
@@ -93,13 +96,17 @@ where
 {
     /// Creates a new [`Manager`] which establishes [`Connection`]s to the given
     /// `database_url`.
+    ///
+    /// [`Connection`]: crate::Connection
     #[must_use]
     pub fn new<S: Into<String>>(database_url: S, runtime: Runtime) -> Self {
         Self::from_config(database_url, runtime, Default::default())
     }
 
-        /// Creates a new [`Manager`] which establishes [`Connection`]s to the given
+    /// Creates a new [`Manager`] which establishes [`Connection`]s to the given
     /// `database_url` with a specific [`ManagerConfig`].
+    ///
+    /// [`Connection`]: crate::Connection
     #[must_use]
     pub fn from_config(
         database_url: impl Into<String>,

--- a/src/managed/builder.rs
+++ b/src/managed/builder.rs
@@ -78,7 +78,7 @@ where
             config: PoolConfig::default(),
             runtime: None,
             hooks: Hooks::default(),
-            _wrapper: PhantomData::default(),
+            _wrapper: PhantomData,
         }
     }
 

--- a/src/managed/mod.rs
+++ b/src/managed/mod.rs
@@ -203,7 +203,7 @@ impl<M: Manager> Object<M> {
     pub fn pool(this: &Self) -> Option<Pool<M>> {
         this.pool.upgrade().map(|inner| Pool {
             inner,
-            _wrapper: PhantomData::default(),
+            _wrapper: PhantomData,
         })
     }
 }
@@ -271,7 +271,7 @@ impl<M: Manager, W: From<Object<M>>> Clone for Pool<M, W> {
     fn clone(&self) -> Self {
         Self {
             inner: self.inner.clone(),
-            _wrapper: PhantomData::default(),
+            _wrapper: PhantomData,
         }
     }
 }
@@ -299,7 +299,7 @@ impl<M: Manager, W: From<Object<M>>> Pool<M, W> {
                 hooks: builder.hooks,
                 runtime: builder.runtime,
             }),
-            _wrapper: PhantomData::default(),
+            _wrapper: PhantomData,
         }
     }
 


### PR DESCRIPTION
This PR adds an option to customize the function used to check whether a certain diesel connection can be recycled or not. This is required to use the connection pool implementation with diesel database connections that do not support the `SELECT 1` ping query used by default. An example of such a database backend is Oracles DBMS, which requires to write `SELECT 1 FROM DUAL`. There is an existing diesel connection implementation for Oracle provided by the `diesel_oci` crate.

In addition the default recycle function was slightly changed to check for open transactions (by asking the `TransactionManager` whether it's broken) before running the ping query. This allows to discard connections with open transactions.