### PR TITLE
Bump up MSRV to 1.63 for all crates and fix CI failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,8 @@ jobs:
       fail-fast: false
       matrix:
         crate:
+          - deadpool-runtime
+          - deadpool-sync
           - deadpool
           - deadpool-diesel
           - deadpool-lapin
@@ -29,9 +31,7 @@ jobs:
           - deadpool-r2d2
           - deadpool-redis
           - deadpool-redis-cluster
-          - deadpool-runtime
           - deadpool-sqlite
-          - deadpool-sync
           # Examples
           - example-postgres-actix-web
           - example-postgres-benchmark
@@ -133,13 +133,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { crate: deadpool, msrv: '1.56.0' }
-          - { crate: deadpool-diesel, msrv: '1.56.0' }
-          - { crate: deadpool-lapin, msrv: '1.59.0' }
-          - { crate: deadpool-postgres, msrv: '1.56.0' }
-          - { crate: deadpool-redis, msrv: '1.59.0' }
-          - { crate: deadpool-redis-cluster, msrv: '1.59.0' }
-          - { crate: deadpool-sqlite, msrv: '1.56.0' }
+          - { crate: deadpool-runtime, msrv: '1.63.0' }
+          - { crate: deadpool-sync, msrv: '1.63.0' }
+          - { crate: deadpool, msrv: '1.63.0' }
+          - { crate: deadpool-diesel, msrv: '1.63.0' }
+          - { crate: deadpool-lapin, msrv: '1.63.0' }
+          - { crate: deadpool-postgres, msrv: '1.63.0' }
+          - { crate: deadpool-redis, msrv: '1.63.0' }
+          - { crate: deadpool-redis-cluster, msrv: '1.63.0' }
+          - { crate: deadpool-sqlite, msrv: '1.63.0' }
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -162,6 +164,8 @@ jobs:
       fail-fast: false
       matrix:
         crate:
+          - deadpool-runtime
+          - deadpool-sync
           - deadpool
           - deadpool-diesel
           - deadpool-lapin
@@ -231,6 +235,8 @@ jobs:
     strategy:
       matrix:
         crate:
+          - deadpool-runtime
+          - deadpool-sync
           - deadpool
           - deadpool-diesel
           - deadpool-lapin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Add `metrics` argument to `Manager::recycle` method.
 - Remove deprecated `managed::sync` module.
 - Remove deprecated `managed::Pool::try_get` method.
+- Bump up MSRV to `1.63` to match the one of `tokio`.
 
 ## v0.9.5
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,14 +3,13 @@ name = "deadpool"
 version = "0.10.0"
 edition = "2018"
 resolver = "2"
+rust-version = "1.63"
 authors = ["Michael P. Jung <michael.jung@terreon.de>"]
 description = "Dead simple async pool"
 keywords = ["async", "database", "pool"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/bikeshedder/deadpool"
 readme = "README.md"
-
-rust-version = "1.54.0"
 
 [package.metadata.docs.rs]
 all-features = true
@@ -25,7 +24,6 @@ rt_async-std_1 = ["deadpool-runtime/async-std_1"]
 
 [dependencies]
 num_cpus = "1.11.1"
-retain_mut = "0.1.6"
 # `managed` feature
 async-trait = { version = "0.1.17", optional = true }
 # `serde` feature

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Deadpool [![Latest Version](https://img.shields.io/crates/v/deadpool.svg)](https://crates.io/crates/deadpool) [![Build Status](https://img.shields.io/github/actions/workflow/status/bikeshedder/deadpool/ci.yml?branch=master)](https://github.com/bikeshedder/deadpool/actions?query=workflow%3ARust) ![Unsafe forbidden](https://img.shields.io/badge/unsafe-forbidden-success.svg "Unsafe forbidden") [![Rust 1.54+](https://img.shields.io/badge/rustc-1.54+-lightgray.svg "Rust 1.54+")](https://blog.rust-lang.org/2021/07/29/Rust-1.54.0.html)
+# Deadpool [![Latest Version](https://img.shields.io/crates/v/deadpool.svg)](https://crates.io/crates/deadpool) [![Build Status](https://img.shields.io/github/actions/workflow/status/bikeshedder/deadpool/ci.yml?branch=master)](https://github.com/bikeshedder/deadpool/actions?query=workflow%3ARust) ![Unsafe forbidden](https://img.shields.io/badge/unsafe-forbidden-success.svg "Unsafe forbidden") [![Rust 1.63+](https://img.shields.io/badge/rustc-1.63+-lightgray.svg "Rust 1.63+")](https://blog.rust-lang.org/2022/08/11/Rust-1.63.0.html)
 
 
 Deadpool is a dead simple async pool for connections and objects

--- a/diesel/CHANGELOG.md
+++ b/diesel/CHANGELOG.md
@@ -2,10 +2,11 @@
 
 ## v0.5.0 (unreleased)
 
-- Update `deadpool` dependency to version `0.10`
+* Update `deadpool` dependency to version `0.10`
 * Add `tracing` feature
 * Check for open transactions before recycling connections
 * Allow to configure a custom recycle check function to customize ping queries for different database backends
+* Bump up MSRV to `1.63` to match the one of `tokio`
 
 ## v0.4.1
 

--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -3,6 +3,7 @@ name = "deadpool-diesel"
 version = "0.5.0"
 edition = "2018"
 resolver = "2"
+rust-version = "1.63"
 authors = ["Michael P. Jung <michael.jung@terreon.de>"]
 description = "Dead simple async pool for diesel"
 keywords = ["async", "database", "pool", "diesel"]

--- a/diesel/README.md
+++ b/diesel/README.md
@@ -1,4 +1,4 @@
-# Deadpool for Diesel [![Latest Version](https://img.shields.io/crates/v/deadpool-diesel.svg)](https://crates.io/crates/deadpool-diesel) ![Unsafe forbidden](https://img.shields.io/badge/unsafe-forbidden-success.svg "Unsafe forbidden") [![Rust 1.54+](https://img.shields.io/badge/rustc-1.54+-lightgray.svg "Rust 1.54+")](https://blog.rust-lang.org/2021/07/29/Rust-1.54.0.html)
+# Deadpool for Diesel [![Latest Version](https://img.shields.io/crates/v/deadpool-diesel.svg)](https://crates.io/crates/deadpool-diesel) ![Unsafe forbidden](https://img.shields.io/badge/unsafe-forbidden-success.svg "Unsafe forbidden") [![Rust 1.63+](https://img.shields.io/badge/rustc-1.63+-lightgray.svg "Rust 1.63+")](https://blog.rust-lang.org/2022/08/11/Rust-1.63.0.html)
 
 Deadpool is a dead simple async pool for connections and objects
 of any type.

--- a/diesel/src/manager.rs
+++ b/diesel/src/manager.rs
@@ -27,14 +27,12 @@ pub struct Manager<C> {
 pub type RecycleCheckCallback<C> = dyn Fn(&mut C) -> Result<(), Error> + Send + Sync;
 
 /// Possible methods of how a connection is recycled.
-#[derive(Default)]
 pub enum RecyclingMethod<C> {
     /// Only check for open transactions when recycling existing connections
     /// Unless you have special needs this is a safe choice.
     ///
     /// If the database connection is closed you will recieve an error on the first place
     /// you actually try to use the connection
-    #[default]
     Fast,
     /// In addition to checking for open transactions a test query is executed
     ///
@@ -46,6 +44,15 @@ pub enum RecyclingMethod<C> {
     ///
     /// The connection is only recycled if the callback returns `Ok(())`
     CustomFunction(Box<RecycleCheckCallback<C>>),
+}
+
+// We use manual implementation here instead of `#[derive(Default)]` as of MSRV 1.63, it generates
+// redundant `C: Default` bound, which imposes problems in the code.
+// TODO: Use `#[derive(Default)]` with `#[default]` attribute once MSRV is bumped to 1.66 or above.
+impl<C> Default for RecyclingMethod<C> {
+    fn default() -> Self {
+        Self::Fast
+    }
 }
 
 /// Configuration object for a Manager.

--- a/lapin/CHANGELOG.md
+++ b/lapin/CHANGELOG.md
@@ -1,9 +1,9 @@
 # Change Log
 
-## v0.11.0
+## v0.11.0 (unreleased)
 
 * Update `deadpool` dependency to version `0.10`
-* Increase MSRV to `1.59`
+* Bump up MSRV to `1.63` to match the one of `tokio`
 
 ## v0.10.0
 

--- a/lapin/Cargo.toml
+++ b/lapin/Cargo.toml
@@ -3,6 +3,7 @@ name = "deadpool-lapin"
 version = "0.11.0"
 edition = "2018"
 resolver = "2"
+rust-version = "1.63"
 authors = ["Michael P. Jung <michael.jung@terreon.de>"]
 description = "Dead simple async pool for lapin"
 keywords = ["async", "lapin", "pool", "amqp", "rabbitmq"]

--- a/lapin/Cargo.toml
+++ b/lapin/Cargo.toml
@@ -32,6 +32,12 @@ serde_1 = { package = "serde", version = "1.0.103", features = [
 ], optional = true }
 tokio-executor-trait = { version = "2.1.0", optional = true }
 
+# Not really used, added to survive `minimal-versions` check only.
+# TODO: Remove once new `async-std` version above 1.12.0 is released,
+#       as it's already fixed in their `main` branch. This, of course,
+#       will require bumping minimal version of `async-std` across the workspace.
+async-global-executor = { version = "2.3.1", optional = true, default-features = false }
+
 [dev-dependencies]
 config = { version = "0.13", features = ["json"] }
 dotenv = "0.15"

--- a/lapin/README.md
+++ b/lapin/README.md
@@ -1,4 +1,4 @@
-# Deadpool for Lapin [![Latest Version](https://img.shields.io/crates/v/deadpool-lapin.svg)](https://crates.io/crates/deadpool-lapin) ![Unsafe forbidden](https://img.shields.io/badge/unsafe-forbidden-success.svg "Unsafe forbidden") [![Rust 1.54+](https://img.shields.io/badge/rustc-1.54+-lightgray.svg "Rust 1.54+")](https://blog.rust-lang.org/2021/07/29/Rust-1.54.0.html)
+# Deadpool for Lapin [![Latest Version](https://img.shields.io/crates/v/deadpool-lapin.svg)](https://crates.io/crates/deadpool-lapin) ![Unsafe forbidden](https://img.shields.io/badge/unsafe-forbidden-success.svg "Unsafe forbidden") [![Rust 1.63+](https://img.shields.io/badge/rustc-1.63+-lightgray.svg "Rust 1.63+")](https://blog.rust-lang.org/2022/08/11/Rust-1.63.0.html)
 
 Deadpool is a dead simple async pool for connections and objects
 of any type.

--- a/memcached/CHANGELOG.md
+++ b/memcached/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update `deadpool` dependency to version `0.10`
+- Bump up MSRV to `1.63` to match the one of `tokio`
 
 ## [0.1.2] - 2020-09-13
 

--- a/memcached/Cargo.toml
+++ b/memcached/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "deadpool-memcached"
 version = "0.2.0"
-resolver = "2"
 edition = "2018"
+resolver = "2"
+rust-version = "1.63"
 authors = [
     "Toby Lawrence <toby@nuclearfurnace.com>",
     "Michael P. Jung <michael.jung@terreon.de>",

--- a/memcached/README.md
+++ b/memcached/README.md
@@ -1,4 +1,4 @@
-# Deadpool for Memcached [![Latest Version](https://img.shields.io/crates/v/deadpool-memcached.svg)](https://crates.io/crates/deadpool-memcached)
+# Deadpool for Memcached [![Latest Version](https://img.shields.io/crates/v/deadpool-memcached.svg)](https://crates.io/crates/deadpool-memcached) [![Rust 1.63+](https://img.shields.io/badge/rustc-1.63+-lightgray.svg "Rust 1.63+")](https://blog.rust-lang.org/2022/08/11/Rust-1.63.0.html)
 
 Deadpool is a dead simple async pool for connections and objects of any type.
 

--- a/postgres/CHANGELOG.md
+++ b/postgres/CHANGELOG.md
@@ -10,6 +10,7 @@
   and dropped as soon as possible. The disconnect is not graceful and
   you might see error messages in the database log.
 - Update `deadpool` dependency to version `0.10`
+- Bump up MSRV to `1.63` to match the one of `tokio`
 
 ## v0.10.5
 

--- a/postgres/Cargo.toml
+++ b/postgres/Cargo.toml
@@ -3,6 +3,7 @@ name = "deadpool-postgres"
 version = "0.11.0"
 edition = "2018"
 resolver = "2"
+rust-version = "1.63"
 authors = ["Michael P. Jung <michael.jung@terreon.de>"]
 description = "Dead simple async pool for tokio-postgres"
 keywords = ["async", "database", "pool", "postgres"]

--- a/postgres/README.md
+++ b/postgres/README.md
@@ -1,4 +1,4 @@
-# Deadpool for PostgreSQL [![Latest Version](https://img.shields.io/crates/v/deadpool-postgres.svg)](https://crates.io/crates/deadpool-postgres) ![Unsafe forbidden](https://img.shields.io/badge/unsafe-forbidden-success.svg "Unsafe forbidden") [![Rust 1.54+](https://img.shields.io/badge/rustc-1.54+-lightgray.svg "Rust 1.54+")](https://blog.rust-lang.org/2021/07/29/Rust-1.54.0.html)
+# Deadpool for PostgreSQL [![Latest Version](https://img.shields.io/crates/v/deadpool-postgres.svg)](https://crates.io/crates/deadpool-postgres) ![Unsafe forbidden](https://img.shields.io/badge/unsafe-forbidden-success.svg "Unsafe forbidden") [![Rust 1.63+](https://img.shields.io/badge/rustc-1.63+-lightgray.svg "Rust 1.63+")](https://blog.rust-lang.org/2022/08/11/Rust-1.63.0.html)
 
 Deadpool is a dead simple async pool for connections and objects
 of any type.

--- a/r2d2/CHANGELOG.md
+++ b/r2d2/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Update `deadpool` dependency to version `0.10`
 * Add `tracing` feature
+* Bump up MSRV to `1.63` to match the one of `tokio`
 
 ## v0.2.0
 

--- a/r2d2/Cargo.toml
+++ b/r2d2/Cargo.toml
@@ -3,6 +3,7 @@ name = "deadpool-r2d2"
 version = "0.3.0"
 edition = "2018"
 resolver = "2"
+rust-version = "1.63"
 authors = ["Michael P. Jung <michael.jung@terreon.de>"]
 description = "Dead simple async pool for r2d2 managers"
 keywords = ["async", "database", "pool", "r2d2"]

--- a/r2d2/README.md
+++ b/r2d2/README.md
@@ -1,4 +1,4 @@
-# Deadpool for R2D2 Managers [![Latest Version](https://img.shields.io/crates/v/deadpool-r2d2.svg)](https://crates.io/crates/deadpool-r2d2) ![Unsafe forbidden](https://img.shields.io/badge/unsafe-forbidden-success.svg "Unsafe forbidden") [![Rust 1.54+](https://img.shields.io/badge/rustc-1.54+-lightgray.svg "Rust 1.54+")](https://blog.rust-lang.org/2021/07/29/Rust-1.54.0.html)
+# Deadpool for R2D2 Managers [![Latest Version](https://img.shields.io/crates/v/deadpool-r2d2.svg)](https://crates.io/crates/deadpool-r2d2) ![Unsafe forbidden](https://img.shields.io/badge/unsafe-forbidden-success.svg "Unsafe forbidden") [![Rust 1.63+](https://img.shields.io/badge/rustc-1.63+-lightgray.svg "Rust 1.63+")](https://blog.rust-lang.org/2022/08/11/Rust-1.63.0.html)
 
 Deadpool is a dead simple async pool for connections and objects
 of any type.

--- a/redis-cluster/Cargo.toml
+++ b/redis-cluster/Cargo.toml
@@ -3,6 +3,7 @@ name = "deadpool-redis-cluster"
 version = "0.2.0"
 edition = "2021"
 resolver = "2"
+rust-version = "1.63"
 authors = [
     "Michael P. Jung <michael.jung@terreon.de>",
     "Subeom Choi <subumm1@gmail.com>",

--- a/redis-cluster/README.md
+++ b/redis-cluster/README.md
@@ -1,4 +1,4 @@
-# Deadpool for Redis Cluster [![Latest Version](https://img.shields.io/crates/v/deadpool-redis-cluster.svg)](https://crates.io/crates/deadpool-redis-cluster) ![Unsafe forbidden](https://img.shields.io/badge/unsafe-forbidden-success.svg "Unsafe forbidden") [![Rust 1.54+](https://img.shields.io/badge/rustc-1.54+-lightgray.svg "Rust 1.54+")](https://blog.rust-lang.org/2021/07/29/Rust-1.54.0.html)
+# Deadpool for Redis Cluster [![Latest Version](https://img.shields.io/crates/v/deadpool-redis-cluster.svg)](https://crates.io/crates/deadpool-redis-cluster) ![Unsafe forbidden](https://img.shields.io/badge/unsafe-forbidden-success.svg "Unsafe forbidden") [![Rust 1.63+](https://img.shields.io/badge/rustc-1.63+-lightgray.svg "Rust 1.63+")](https://blog.rust-lang.org/2022/08/11/Rust-1.63.0.html)
 
 Deadpool is a dead simple async pool for connections and objects
 of any type.

--- a/redis/CHANGELOG.md
+++ b/redis/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.13.0 (unreleased)
 
 * Update `deadpool` dependency to version `0.10`
+* Bump up MSRV to `1.63` to match the one of `tokio`
 
 ## v0.12.0
 

--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -3,6 +3,7 @@ name = "deadpool-redis"
 version = "0.13.0"
 edition = "2018"
 resolver = "2"
+rust-version = "1.63"
 authors = ["Michael P. Jung <michael.jung@terreon.de>"]
 description = "Dead simple async pool for redis"
 keywords = ["async", "redis", "pool"]

--- a/redis/README.md
+++ b/redis/README.md
@@ -1,4 +1,4 @@
-# Deadpool for Redis [![Latest Version](https://img.shields.io/crates/v/deadpool-redis.svg)](https://crates.io/crates/deadpool-redis) ![Unsafe forbidden](https://img.shields.io/badge/unsafe-forbidden-success.svg "Unsafe forbidden") [![Rust 1.59+](https://img.shields.io/badge/rustc-1.59+-lightgray.svg "Rust 1.59+")](https://blog.rust-lang.org/2022/02/24/Rust-1.59.0.html)
+# Deadpool for Redis [![Latest Version](https://img.shields.io/crates/v/deadpool-redis.svg)](https://crates.io/crates/deadpool-redis) ![Unsafe forbidden](https://img.shields.io/badge/unsafe-forbidden-success.svg "Unsafe forbidden") [![Rust 1.63+](https://img.shields.io/badge/rustc-1.63+-lightgray.svg "Rust 1.63+")](https://blog.rust-lang.org/2022/08/11/Rust-1.63.0.html)
 
 Deadpool is a dead simple async pool for connections and objects
 of any type.

--- a/runtime/CHANGELOG.md
+++ b/runtime/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.1.3 (unreleased)
+
+* Bump up MSRV to `1.63` to match the one of `tokio`
+
 ## v0.1.2
 
 * Fix links to tokio and async-std in documentation

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -3,6 +3,7 @@ name = "deadpool-runtime"
 version = "0.1.2"
 edition = "2018"
 resolver = "2"
+rust-version = "1.63"
 authors = ["Michael P. Jung <michael.jung@terreon.de>"]
 description = "Dead simple async pool utitities for sync managers"
 keywords = ["async", "database", "pool", "sync", "utils"]

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -1,4 +1,4 @@
-# Deadpool runtime abstraction [![Latest Version](https://img.shields.io/crates/v/deadpool-runtime.svg)](https://crates.io/crates/deadpool-runtime) ![Unsafe forbidden](https://img.shields.io/badge/unsafe-forbidden-success.svg "Unsafe forbidden") [![Rust 1.54+](https://img.shields.io/badge/rustc-1.54+-lightgray.svg "Rust 1.54+")](https://blog.rust-lang.org/2021/07/29/Rust-1.54.0.html)
+# Deadpool runtime abstraction [![Latest Version](https://img.shields.io/crates/v/deadpool-runtime.svg)](https://crates.io/crates/deadpool-runtime) ![Unsafe forbidden](https://img.shields.io/badge/unsafe-forbidden-success.svg "Unsafe forbidden") [![Rust 1.63+](https://img.shields.io/badge/rustc-1.63+-lightgray.svg "Rust 1.63+")](https://blog.rust-lang.org/2022/08/11/Rust-1.63.0.html)
 
 Deadpool is a dead simple async pool for connections and objects
 of any type.

--- a/sqlite/CHANGELOG.md
+++ b/sqlite/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Update `deadpool` dependency to version `0.10`
 * Update `rusqlite` dependency to version `0.29`
 * Add `tracing` feature
+* Bump up MSRV to `1.63` to match the one of `tokio`
 
 ## v0.5.0
 

--- a/sqlite/Cargo.toml
+++ b/sqlite/Cargo.toml
@@ -3,6 +3,7 @@ name = "deadpool-sqlite"
 version = "0.6.0"
 edition = "2021"
 resolver = "2"
+rust-version = "1.63"
 authors = ["Michael P. Jung <michael.jung@terreon.de>"]
 description = "Dead simple async pool for rusqlite"
 keywords = ["async", "database", "pool", "sqlite"]

--- a/sqlite/README.md
+++ b/sqlite/README.md
@@ -1,4 +1,4 @@
-# Deadpool for SQLite [![Latest Version](https://img.shields.io/crates/v/deadpool-sqlite.svg)](https://crates.io/crates/deadpool-sqlite) ![Unsafe forbidden](https://img.shields.io/badge/unsafe-forbidden-success.svg "Unsafe forbidden") [![Rust 1.56+](https://img.shields.io/badge/rustc-1.56+-lightgray.svg "Rust 1.56+")](https://blog.rust-lang.org/2021/10/21/Rust-1.56.0.html)
+# Deadpool for SQLite [![Latest Version](https://img.shields.io/crates/v/deadpool-sqlite.svg)](https://crates.io/crates/deadpool-sqlite) ![Unsafe forbidden](https://img.shields.io/badge/unsafe-forbidden-success.svg "Unsafe forbidden") [![Rust 1.63+](https://img.shields.io/badge/rustc-1.63+-lightgray.svg "Rust 1.63+")](https://blog.rust-lang.org/2022/08/11/Rust-1.63.0.html)
 
 Deadpool is a dead simple async pool for connections and objects
 of any type.

--- a/src/managed/mod.rs
+++ b/src/managed/mod.rs
@@ -73,10 +73,6 @@ use std::{
 
 use async_trait::async_trait;
 use deadpool_runtime::Runtime;
-// retain_mut is included since Rust 1.61
-// deadpool has a MSRV of 1.54
-#[allow(deprecated)]
-use retain_mut::RetainMut;
 use tokio::sync::{Semaphore, TryAcquireError};
 
 pub use crate::Status;
@@ -520,8 +516,7 @@ impl<M: Manager, W: From<Object<M>>> Pool<M, W> {
     pub fn retain(&self, f: impl Fn(&M::Type, Metrics) -> bool) {
         let mut guard = self.inner.slots.lock().unwrap();
         let len_before = guard.vec.len();
-        #[allow(deprecated)]
-        RetainMut::retain_mut(&mut guard.vec, |obj| {
+        guard.vec.retain_mut(|obj| {
             if f(&obj.obj, obj.metrics) {
                 true
             } else {

--- a/sync/CHANGELOG.md
+++ b/sync/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## v0.1.2 (unreleased)
 
 * Add `tracing` feature to `README`
-* Fix MSRV `1.56` (This was the reason for yanking the `0.1.1` release)
+* Fix MSRV (this was the reason for yanking the `0.1.1` release) and bump it up to `1.63` to match the one of `tokio`
 
 ## v0.1.1 (yanked)
 

--- a/sync/Cargo.toml
+++ b/sync/Cargo.toml
@@ -3,6 +3,7 @@ name = "deadpool-sync"
 version = "0.1.1"
 edition = "2018"
 resolver = "2"
+rust-version = "1.63"
 authors = ["Michael P. Jung <michael.jung@terreon.de>"]
 description = "Dead simple async pool utitities for sync managers"
 keywords = ["async", "database", "pool", "sync", "utils"]

--- a/sync/README.md
+++ b/sync/README.md
@@ -1,4 +1,4 @@
-# Deadpool for synchroneous code [![Latest Version](https://img.shields.io/crates/v/deadpool-sync.svg)](https://crates.io/crates/deadpool-sync) ![Unsafe forbidden](https://img.shields.io/badge/unsafe-forbidden-success.svg "Unsafe forbidden") [![Rust 1.54+](https://img.shields.io/badge/rustc-1.54+-lightgray.svg "Rust 1.54+")](https://blog.rust-lang.org/2021/07/29/Rust-1.54.0.html)
+# Deadpool for synchroneous code [![Latest Version](https://img.shields.io/crates/v/deadpool-sync.svg)](https://crates.io/crates/deadpool-sync) ![Unsafe forbidden](https://img.shields.io/badge/unsafe-forbidden-success.svg "Unsafe forbidden") [![Rust 1.63+](https://img.shields.io/badge/rustc-1.63+-lightgray.svg "Rust 1.63+")](https://blog.rust-lang.org/2022/08/11/Rust-1.63.0.html)
 
 Deadpool is a dead simple async pool for connections and objects
 of any type.


### PR DESCRIPTION
Resolves #270 

## Background

See #270 for details.

> The CI pipeline currently fails because clippy doesn't respect the `rust-version` in the `Cargo.toml` and the MSRV checks fail for some other strange reasons.

> I think it is safe to increase the MSRV to 1.56 or even 1.59 for all crates.
> 
> Just as a reference: The current `tokio` release specifies `1.63` as MSRV.



## Solution

Bump up MSRV to 1.63, since there is no meaningful reason to keep it below `tokio`.



## Additionally

- Remove `retain_mut` polyfill usage in `deadpool` crate.
- Extend CI matrix to test and check docs for `deadpool-runtime` and `deadpool-sync` crate separately.


## Checklist

- [x] `README.md` badges updated
- [x] `CHANGELOG.md` entries added
- [x] `rust-version` is specified in `Cargo.toml`
- [x] CI pipeline updated  
