### PR TITLE
Redis v0.23.4

### DIFF
--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -25,7 +25,9 @@ serde = ["deadpool/serde", "serde_1"]
 deadpool = { path = "../", version = "0.10.0", default-features = false, features = [
     "managed",
 ] }
-redis = { version = "0.23", default-features = false, features = ["aio"] }
+redis = { version = ">=0.23.4, <0.24", default-features = false, features = [
+    "aio",
+] }
 serde_1 = { package = "serde", version = "1.0", features = [
     "derive",
 ], optional = true }
@@ -34,7 +36,7 @@ serde_1 = { package = "serde", version = "1.0", features = [
 config = { version = "0.13", features = ["json"] }
 dotenv = "0.15.0"
 futures = "0.3.15"
-redis = { version = "0.23", default-features = false, features = [
+redis = { version = ">=0.23.4, <0.24", default-features = false, features = [
     "tokio-comp",
 ] }
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }

--- a/redis/src/config.rs
+++ b/redis/src/config.rs
@@ -175,6 +175,7 @@ impl From<ConnectionAddr> for redis::ConnectionAddr {
                 host,
                 port,
                 insecure,
+                tls_params: None,
             },
             ConnectionAddr::Unix(path) => Self::Unix(path),
         }
@@ -189,6 +190,7 @@ impl From<redis::ConnectionAddr> for ConnectionAddr {
                 host,
                 port,
                 insecure,
+                tls_params,
             } => ConnectionAddr::TcpTls {
                 host,
                 port,


### PR DESCRIPTION
I made some changes to satisfy the connection from `redis` temporarily.
I believe they modify TcpTls to support Mutual TLS and that may need more effort to configure all kinds of TLS (native + rustls).
It's pretty awkward because this should be warned as incompatible update.
