### PR TITLE
Update to redis v0.24

### DIFF
--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -25,7 +25,7 @@ serde = ["deadpool/serde", "serde_1"]
 deadpool = { path = "../", version = "0.10.0", default-features = false, features = [
     "managed",
 ] }
-redis = { version = "0.23", default-features = false, features = ["aio"] }
+redis = { version = "0.24", default-features = false, features = ["aio"] }
 serde_1 = { package = "serde", version = "1.0", features = [
     "derive",
 ], optional = true }
@@ -34,7 +34,7 @@ serde_1 = { package = "serde", version = "1.0", features = [
 config = { version = "0.13", features = ["json"] }
 dotenv = "0.15.0"
 futures = "0.3.15"
-redis = { version = "0.23", default-features = false, features = [
+redis = { version = "0.24", default-features = false, features = [
     "tokio-comp",
 ] }
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }

--- a/redis/src/config.rs
+++ b/redis/src/config.rs
@@ -124,7 +124,8 @@ impl Default for Config {
     }
 }
 
-/// This is a 1:1 copy of the [`redis::ConnectionAddr`] enumeration.
+/// This is a 1:1 copy of the [`redis::ConnectionAddr`] enumeration (excluding `tls_params` since it is entirely opaque to consumers).
+///
 /// This is duplicated here in order to add support for the
 /// [`serde::Deserialize`] trait which is required for the [`serde`] support.
 #[derive(Clone, Debug)]
@@ -175,6 +176,7 @@ impl From<ConnectionAddr> for redis::ConnectionAddr {
                 host,
                 port,
                 insecure,
+                tls_params: None,
             },
             ConnectionAddr::Unix(path) => Self::Unix(path),
         }
@@ -189,6 +191,7 @@ impl From<redis::ConnectionAddr> for ConnectionAddr {
                 host,
                 port,
                 insecure,
+                ..
             } => ConnectionAddr::TcpTls {
                 host,
                 port,


### PR DESCRIPTION
Updates the version of `redis` used by `deadpool-redis` to v0.24