### PR TITLE
diesel: Fix reexported error types

### DIFF
--- a/diesel/src/mysql.rs
+++ b/diesel/src/mysql.rs
@@ -9,7 +9,7 @@ deadpool::managed_reexports!(
     "diesel",
     Manager,
     deadpool::managed::Object<Manager>,
-    diesel::ConnectionError,
+    crate::Error,
     std::convert::Infallible
 );
 

--- a/diesel/src/postgres.rs
+++ b/diesel/src/postgres.rs
@@ -9,7 +9,7 @@ deadpool::managed_reexports!(
     "diesel",
     Manager,
     deadpool::managed::Object<Manager>,
-    diesel::ConnectionError,
+    crate::Error,
     std::convert::Infallible
 );
 

--- a/diesel/src/sqlite.rs
+++ b/diesel/src/sqlite.rs
@@ -9,7 +9,7 @@ deadpool::managed_reexports!(
     "diesel",
     Manager,
     deadpool::managed::Object<Manager>,
-    diesel::ConnectionError,
+    crate::Error,
     std::convert::Infallible
 );
 


### PR DESCRIPTION
The error type passed into `managed_reexports!()` generates two type aliases: `PoolError<E>` and `HookError<E>`.

`PoolError<M::Error>` is used e.g. by the `get()` fn of managed pools. But `M::Error` for the `Manager` in the `deadpool_diesel` crate is defined as `deadpool_diesel::Error`, not `diesel::ConnectionError`, which makes the reexport wrong or at least not as useful as it is meant to be. Interestingly, there is another `PoolError` type alias in the root module of `deadpool_diesel` with the correct generic type signature.

`HookError<M::Error>` is used e.g. in the `post_create()` fn of the managed pool builders. As above, `M::Error` is defined as `deadpool_diesel::Error`, not `diesel::ConnectionError`. In this case there is no correct root module type alias either, which requires users to add a dependency on `deadpool` itself to get to the generic, non-type-alias variant of `HookError`.