### PR TITLE
Update redis to 0.25.

### DIFF
--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -28,7 +28,7 @@ cluster = ["redis/cluster-async"]
 deadpool = { path = "../", version = "0.10.0", default-features = false, features = [
     "managed",
 ] }
-redis = { version = "0.24", default-features = false, features = ["aio"] }
+redis = { version = "0.25", default-features = false, features = ["aio"] }
 serde = { package = "serde", version = "1.0", features = [
     "derive",
 ], optional = true }
@@ -37,7 +37,7 @@ serde = { package = "serde", version = "1.0", features = [
 config = { version = "0.13", features = ["json"] }
 dotenvy = "0.15.0"
 futures = "0.3.15"
-redis = { version = "0.24", default-features = false, features = [
+redis = { version = "0.25", default-features = false, features = [
     "tokio-comp",
 ] }
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }


### PR DESCRIPTION
This updates Redis to 0.25 + updates `aio::Connection` to `aio::MultiplexedConnection` (as `aio::Connection` has been deprecated). I think it depends on the use-case if people want to use the same `MultiplexedConnection` for multiple queries, or want to create new `MultiplexedConnection`s for each query (there are some queries that will block the `MultiplexedConnection`, in which case you might want to use multiple connections).

See also #305.