### PR TITLE
Timeouts: Make `new()` and `wait_millis()` const fns

### DIFF
--- a/src/managed/config.rs
+++ b/src/managed/config.rs
@@ -75,7 +75,7 @@ pub struct Timeouts {
 impl Timeouts {
     /// Create an empty [`Timeouts`] config (no timeouts set).
     #[must_use]
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
             create: None,
             wait: None,
@@ -86,7 +86,7 @@ impl Timeouts {
     /// Creates a new [`Timeouts`] config with only the `wait` timeout being
     /// set.
     #[must_use]
-    pub fn wait_millis(wait: u64) -> Self {
+    pub const fn wait_millis(wait: u64) -> Self {
         Self {
             create: None,
             wait: Some(Duration::from_millis(wait)),

--- a/src/managed/config.rs
+++ b/src/managed/config.rs
@@ -76,7 +76,11 @@ impl Timeouts {
     /// Create an empty [`Timeouts`] config (no timeouts set).
     #[must_use]
     pub fn new() -> Self {
-        Self::default()
+        Self {
+            create: None,
+            wait: None,
+            recycle: None,
+        }
     }
 
     /// Creates a new [`Timeouts`] config with only the `wait` timeout being
@@ -95,11 +99,7 @@ impl Timeouts {
 impl Default for Timeouts {
     /// Creates an empty [`Timeouts`] config (no timeouts set).
     fn default() -> Self {
-        Self {
-            create: None,
-            wait: None,
-            recycle: None,
-        }
+        Self::new()
     }
 }
 


### PR DESCRIPTION
This allows users to declare e.g. `const TIMEOUTS: Timeouts = Timeouts::wait_millis(500);` without the compiler screaming at them. This is made possible by the fact that `Duration::from_millis()` is also a `const fn` since Rust 1.32.