### PR TITLE
Expose API for providing a custom Connect impl and pass through the `runtime` feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,32 @@ jobs:
       - run: cargo check -p deadpool-${{ matrix.crate }}
                    --features ${{ matrix.feature }}
 
+  check-integration-wasm:
+    name: Check integration (WebAssembly)
+    strategy:
+      fail-fast: false
+      matrix:
+        crate:
+          - postgres
+        feature:
+          - --features rt_tokio_1
+          - --features rt_async-std_1
+          - --features serde --features rt_tokio_1
+          - --features serde --features rt_async-std_1
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          target: wasm32-unknown-unknown
+
+      - run: cargo check -p deadpool-${{ matrix.crate }}
+                   --no-default-features
+                   ${{ matrix.feature }}
+                   --target wasm32-unknown-unknown
+
   msrv:
     name: MSRV
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,9 +134,7 @@ jobs:
           - postgres
         feature:
           - --features rt_tokio_1
-          - --features rt_async-std_1
           - --features serde --features rt_tokio_1
-          - --features serde --features rt_async-std_1
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/postgres/Cargo.toml
+++ b/postgres/Cargo.toml
@@ -31,6 +31,9 @@ tokio = { version = "1.29", features = ["rt"] }
 tokio-postgres = { version = "0.7.9", default-features = false }
 tracing = "0.1.37"
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom = { version = "0.2", features = ["js"] }
+
 [dev-dependencies]
 config = { version = "0.14", features = ["json"] }
 dotenvy = "0.15.0"

--- a/postgres/Cargo.toml
+++ b/postgres/Cargo.toml
@@ -14,7 +14,8 @@ readme = "README.md"
 all-features = true
 
 [features]
-default = ["rt_tokio_1"]
+default = ["runtime", "rt_tokio_1"]
+runtime = ["tokio-postgres/runtime"]
 rt_tokio_1 = ["deadpool/rt_tokio_1"]
 rt_async-std_1 = ["deadpool/rt_async-std_1"]
 serde = ["deadpool/serde", "dep:serde"]
@@ -27,7 +28,7 @@ serde = { package = "serde", version = "1.0", features = [
     "derive",
 ], optional = true }
 tokio = { version = "1.29", features = ["rt"] }
-tokio-postgres = "0.7.9"
+tokio-postgres = { version = "0.7.9", default-features = false }
 tracing = "0.1.37"
 
 [dev-dependencies]

--- a/src/managed/metrics.rs
+++ b/src/managed/metrics.rs
@@ -1,11 +1,14 @@
+#[cfg(not(target_arch = "wasm32"))]
 use std::time::{Duration, Instant};
 
 /// Statistics regarding an object returned by the pool
 #[derive(Clone, Copy, Debug)]
 #[must_use]
 pub struct Metrics {
+    #[cfg(not(target_arch = "wasm32"))]
     /// The instant when this object was created
     pub created: Instant,
+    #[cfg(not(target_arch = "wasm32"))]
     /// The instant when this object was last used
     pub recycled: Option<Instant>,
     /// The number of times the objects was recycled
@@ -13,10 +16,12 @@ pub struct Metrics {
 }
 
 impl Metrics {
+    #[cfg(not(target_arch = "wasm32"))]
     /// Access the age of this object
     pub fn age(&self) -> Duration {
         self.created.elapsed()
     }
+    #[cfg(not(target_arch = "wasm32"))]
     /// Get the time elapsed when this object was last used
     pub fn last_used(&self) -> Duration {
         self.recycled.unwrap_or(self.created).elapsed()
@@ -26,7 +31,9 @@ impl Metrics {
 impl Default for Metrics {
     fn default() -> Self {
         Self {
+            #[cfg(not(target_arch = "wasm32"))]
             created: Instant::now(),
+            #[cfg(not(target_arch = "wasm32"))]
             recycled: None,
             recycle_count: 0,
         }

--- a/src/managed/mod.rs
+++ b/src/managed/mod.rs
@@ -66,8 +66,11 @@ use std::{
         atomic::{AtomicUsize, Ordering},
         Arc, Mutex, Weak,
     },
-    time::{Duration, Instant},
+    time::Duration,
 };
+
+#[cfg(not(target_arch = "wasm32"))]
+use std::time::Instant;
 
 use deadpool_runtime::Runtime;
 use tokio::sync::{Semaphore, TryAcquireError};
@@ -409,7 +412,10 @@ impl<M: Manager, W: From<Object<M>>> Pool<M, W> {
         }
 
         inner.metrics.recycle_count += 1;
-        inner.metrics.recycled = Some(Instant::now());
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            inner.metrics.recycled = Some(Instant::now());
+        }
 
         Ok(Some(unready_obj.ready()))
     }


### PR DESCRIPTION
Currently, `deadpool-postgres` only offers APIs for creating pools that instantiate their underlying connections based on a `tokio_postgres::Config`. In some situations (mocking, custom networking), it is useful to provide an alternate connection mechanism. Thankfully, `deadpool-postgres` already has the `Client` trait for this so we just need to expose it publicly. As part of this, we also expose the existing `ConnectImpl` as a public `ConfigConnectImpl` for code that needs to abstract over a selection of connection strategy.

Our main use case for this is to enable use on WASM, where `tokio_postgres` is already supported but does not have the `tokio-postgres/runtime` feature enabled (which enables the APIs for creation based on a database URL). So this PR also adds a `runtime` feature that maps to the underlying `tokio-postgres` one for now (defaulting to true to preserve compatibility). It also includes a minor patch to disable the `keepalives_idle` config on WASM where it is not supported.