### PR TITLE
Add license files to published deadpool-* crates

### DIFF
--- a/diesel/LICENSE-APACHE
+++ b/diesel/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/diesel/LICENSE-MIT
+++ b/diesel/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/lapin/LICENSE-APACHE
+++ b/lapin/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/lapin/LICENSE-MIT
+++ b/lapin/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/memcached/LICENSE-APACHE
+++ b/memcached/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/memcached/LICENSE-MIT
+++ b/memcached/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/postgres/LICENSE-APACHE
+++ b/postgres/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/postgres/LICENSE-MIT
+++ b/postgres/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/r2d2/LICENSE-APACHE
+++ b/r2d2/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/r2d2/LICENSE-MIT
+++ b/r2d2/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/redis/LICENSE-APACHE
+++ b/redis/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/redis/LICENSE-MIT
+++ b/redis/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/runtime/LICENSE-APACHE
+++ b/runtime/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/runtime/LICENSE-MIT
+++ b/runtime/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/sqlite/LICENSE-APACHE
+++ b/sqlite/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/sqlite/LICENSE-MIT
+++ b/sqlite/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/sync/LICENSE-APACHE
+++ b/sync/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/sync/LICENSE-MIT
+++ b/sync/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT


### PR DESCRIPTION
Add symbolic links so that `LICENSE-APACHE` and `LICENSE-MIT` are included in all of the published `deadpool-*` crates, as required by the terms of the chosen licenses.

Before this PR:

```
$ gh repo clone bikeshedder/deadpool
$ cd deadpool/runtime
$ cargo publish --dry-run
$ tar -tzvf ../target/package/deadpool-runtime-0.1.3.crate
-rw-r--r-- 0/0             101 1969-12-31 19:00 deadpool-runtime-0.1.3/.cargo_vcs_info.json
-rw-r--r-- 0/0            1087 2006-07-23 21:21 deadpool-runtime-0.1.3/CHANGELOG.md
-rw-r--r-- 0/0            1087 1969-12-31 19:00 deadpool-runtime-0.1.3/Cargo.toml
-rw-r--r-- 0/0             704 2006-07-23 21:21 deadpool-runtime-0.1.3/Cargo.toml.orig
-rw-r--r-- 0/0            1486 2006-07-23 21:21 deadpool-runtime-0.1.3/README.md
-rw-r--r-- 0/0            4047 2006-07-23 21:21 deadpool-runtime-0.1.3/src/lib.rs
```

After this PR:

```
$ cargo publish --dry-run
$ tar -tzvf ../target/package/deadpool-runtime-0.1.3.crate
-rw-r--r-- 0/0             101 1969-12-31 19:00 deadpool-runtime-0.1.3/.cargo_vcs_info.json
-rw-r--r-- 0/0            1087 2006-07-23 21:21 deadpool-runtime-0.1.3/CHANGELOG.md
-rw-r--r-- 0/0            1087 1969-12-31 19:00 deadpool-runtime-0.1.3/Cargo.toml
-rw-r--r-- 0/0             704 2006-07-23 21:21 deadpool-runtime-0.1.3/Cargo.toml.orig
-rw-r--r-- 0/0           11346 2006-07-23 21:21 deadpool-runtime-0.1.3/LICENSE-APACHE
-rw-r--r-- 0/0            1083 2006-07-23 21:21 deadpool-runtime-0.1.3/LICENSE-MIT
-rw-r--r-- 0/0            1486 2006-07-23 21:21 deadpool-runtime-0.1.3/README.md
-rw-r--r-- 0/0            4047 2006-07-23 21:21 deadpool-runtime-0.1.3/src/lib.rs
```

Note that the symbolic links are resolved by `cargo publish`, and the resulting crates contain the license texts as regular files.