### PR TITLE
chore: bump `redis` to 0.26

### DIFF
--- a/redis/CHANGELOG.md
+++ b/redis/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Update `redis` dependency to version `0.26`
+
 ## [0.15.1] - 2024-05-04
 
 - Update `deadpool` dependency to version `0.12`

--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -28,7 +28,7 @@ cluster = ["redis/cluster-async"]
 deadpool = { path = "../", version = "0.12.0", default-features = false, features = [
     "managed",
 ] }
-redis = { version = "0.25", default-features = false, features = ["aio"] }
+redis = { version = "0.26", default-features = false, features = ["aio"] }
 serde = { package = "serde", version = "1.0", features = [
     "derive",
 ], optional = true }
@@ -37,7 +37,7 @@ serde = { package = "serde", version = "1.0", features = [
 config = { version = "0.14", features = ["json"] }
 dotenvy = "0.15.0"
 futures = "0.3.15"
-redis = { version = "0.25", default-features = false, features = [
+redis = { version = "0.26", default-features = false, features = [
     "tokio-comp",
 ] }
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }

--- a/redis/README.md
+++ b/redis/README.md
@@ -30,7 +30,7 @@ async fn main() {
         let mut conn = pool.get().await.unwrap();
         cmd("SET")
             .arg(&["deadpool/test_key", "42"])
-            .query_async::<_, ()>(&mut conn)
+            .query_async::<()>(&mut conn)
             .await.unwrap();
     }
     {
@@ -74,7 +74,7 @@ async fn main() {
         let mut conn = pool.get().await.unwrap();
         cmd("SET")
             .arg(&["deadpool/test_key", "42"])
-            .query_async::<_, ()>(&mut conn)
+            .query_async::<()>(&mut conn)
             .await.unwrap();
     }
     {
@@ -108,7 +108,7 @@ async fn main() {
         let mut conn = pool.get().await.unwrap();
         cmd("SET")
             .arg(&["deadpool/test_key", "42"])
-            .query_async::<_, ()>(&mut conn)
+            .query_async::<()>(&mut conn)
             .await.unwrap();
     }
     {
@@ -158,7 +158,7 @@ async fn main() {
         let mut conn = pool.get().await.unwrap();
         cmd("SET")
             .arg(&["deadpool/test_key", "42"])
-            .query_async::<_, ()>(&mut conn)
+            .query_async::<()>(&mut conn)
             .await.unwrap();
     }
     {

--- a/redis/src/cluster/mod.rs
+++ b/redis/src/cluster/mod.rs
@@ -144,7 +144,7 @@ impl managed::Manager for Manager {
         let ping_number = self.ping_number.fetch_add(1, Ordering::Relaxed).to_string();
         let n = redis::cmd("PING")
             .arg(&ping_number)
-            .query_async::<_, String>(conn)
+            .query_async::<String>(conn)
             .await?;
         if n == ping_number {
             Ok(())

--- a/redis/src/config.rs
+++ b/redis/src/config.rs
@@ -1,6 +1,6 @@
 use std::{fmt, path::PathBuf};
 
-use redis::RedisError;
+use redis::{ProtocolVersion, RedisError};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
@@ -251,6 +251,9 @@ pub struct RedisConnectionInfo {
 
     /// Optionally a password that should be used for connection.
     pub password: Option<String>,
+
+    /// Version of the protocol to use.
+    pub protocol: ProtocolVersion,
 }
 
 impl From<RedisConnectionInfo> for redis::RedisConnectionInfo {
@@ -259,6 +262,7 @@ impl From<RedisConnectionInfo> for redis::RedisConnectionInfo {
             db: info.db,
             username: info.username,
             password: info.password,
+            protocol: info.protocol,
         }
     }
 }
@@ -269,6 +273,7 @@ impl From<redis::RedisConnectionInfo> for RedisConnectionInfo {
             db: info.db,
             username: info.username,
             password: info.password,
+            protocol: info.protocol,
         }
     }
 }

--- a/redis/src/config.rs
+++ b/redis/src/config.rs
@@ -1,6 +1,6 @@
 use std::{fmt, path::PathBuf};
 
-use redis::{ProtocolVersion, RedisError};
+use redis::RedisError;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
@@ -256,24 +256,46 @@ pub struct RedisConnectionInfo {
     pub protocol: ProtocolVersion,
 }
 
+/// This is a 1:1 copy of the [`redis::ProtocolVersion`] struct.
+/// Enum representing the communication protocol with the server. This enum represents the types
+/// of data that the server can send to the client, and the capabilities that the client can use.
+#[derive(Clone, Eq, PartialEq, Default, Debug, Copy)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", serde(crate = "serde"))]
+pub enum ProtocolVersion {
+    /// <https://github.com/redis/redis-specifications/blob/master/protocol/RESP2.md>
+    #[default]
+    RESP2,
+    /// <https://github.com/redis/redis-specifications/blob/master/protocol/RESP3.md>
+    RESP3,
+}
+
 impl From<RedisConnectionInfo> for redis::RedisConnectionInfo {
     fn from(info: RedisConnectionInfo) -> Self {
+        let protocol = match info.protocol {
+            ProtocolVersion::RESP2 => redis::ProtocolVersion::RESP2,
+            ProtocolVersion::RESP3 => redis::ProtocolVersion::RESP3,
+        };
         Self {
             db: info.db,
             username: info.username,
             password: info.password,
-            protocol: info.protocol,
+            protocol,
         }
     }
 }
 
 impl From<redis::RedisConnectionInfo> for RedisConnectionInfo {
     fn from(info: redis::RedisConnectionInfo) -> Self {
+        let protocol = match info.protocol {
+            redis::ProtocolVersion::RESP2 => ProtocolVersion::RESP2,
+            redis::ProtocolVersion::RESP3 => ProtocolVersion::RESP3,
+        };
         Self {
             db: info.db,
             username: info.username,
             password: info.password,
-            protocol: info.protocol,
+            protocol,
         }
     }
 }

--- a/redis/src/lib.rs
+++ b/redis/src/lib.rs
@@ -159,7 +159,7 @@ impl managed::Manager for Manager {
             .ignore()
             .cmd("PING")
             .arg(&ping_number)
-            .query_async::<_, (String,)>(conn)
+            .query_async::<(String,)>(conn)
             .await?;
         if n == ping_number {
             Ok(())

--- a/redis/tests/redis.rs
+++ b/redis/tests/redis.rs
@@ -186,7 +186,7 @@ async fn test_recycled_with_watch() {
             .unwrap();
         assert_eq!(
             txn_result,
-            Value::Okay,
+            Value::Array(vec![Value::Okay]),
             "redis transaction in recycled connection aborted",
         );
     }

--- a/redis/tests/redis.rs
+++ b/redis/tests/redis.rs
@@ -71,7 +71,7 @@ async fn test_aborted_command() {
         // https://github.com/mitsuhiko/redis-rs/issues/489
         cmd("PING")
             .arg("wrong")
-            .query_async::<_, String>(&mut conn)
+            .query_async::<String>(&mut conn)
             .now_or_never();
     }
     {
@@ -94,7 +94,7 @@ async fn test_recycled() {
 
         cmd("CLIENT")
             .arg("ID")
-            .query_async::<_, i64>(&mut conn)
+            .query_async::<i64>(&mut conn)
             .await
             .unwrap()
     };
@@ -104,7 +104,7 @@ async fn test_recycled() {
 
         let new_client_id = cmd("CLIENT")
             .arg("ID")
-            .query_async::<_, i64>(&mut conn)
+            .query_async::<i64>(&mut conn)
             .await
             .unwrap();
 
@@ -130,13 +130,13 @@ async fn test_recycled_with_watch() {
 
         let client_id = cmd("CLIENT")
             .arg("ID")
-            .query_async::<_, i64>(&mut conn)
+            .query_async::<i64>(&mut conn)
             .await
             .unwrap();
 
         cmd("WATCH")
             .arg(WATCHED_KEY)
-            .query_async::<_, ()>(&mut conn)
+            .query_async::<()>(&mut conn)
             .await
             .unwrap();
 
@@ -148,7 +148,7 @@ async fn test_recycled_with_watch() {
 
         let new_client_id = cmd("CLIENT")
             .arg("ID")
-            .query_async::<_, i64>(&mut txn_conn)
+            .query_async::<i64>(&mut txn_conn)
             .await
             .unwrap();
 
@@ -161,7 +161,7 @@ async fn test_recycled_with_watch() {
         // Start transaction on another key
         cmd("WATCH")
             .arg(TXN_KEY)
-            .query_async::<_, ()>(&mut txn_conn)
+            .query_async::<()>(&mut txn_conn)
             .await
             .unwrap();
 
@@ -172,7 +172,7 @@ async fn test_recycled_with_watch() {
             cmd("SET")
                 .arg(WATCHED_KEY)
                 .arg("v")
-                .query_async::<_, ()>(&mut writer_conn)
+                .query_async::<()>(&mut writer_conn)
                 .await
                 .unwrap();
         }
@@ -181,12 +181,12 @@ async fn test_recycled_with_watch() {
         let txn_result = pipe()
             .atomic()
             .set(TXN_KEY, "foo")
-            .query_async::<_, Value>(&mut txn_conn)
+            .query_async::<Value>(&mut txn_conn)
             .await
             .unwrap();
         assert_eq!(
             txn_result,
-            Value::Bulk(vec![Value::Okay]),
+            Value::Okay,
             "redis transaction in recycled connection aborted",
         );
     }

--- a/redis/tests/redis_cluster.rs
+++ b/redis/tests/redis_cluster.rs
@@ -76,7 +76,7 @@ async fn test_aborted_command() {
         // https://github.com/mitsuhiko/redis-rs/issues/489
         cmd("PING")
             .arg("wrong")
-            .query_async::<_, String>(&mut conn)
+            .query_async::<String>(&mut conn)
             .now_or_never();
     }
     {
@@ -99,7 +99,7 @@ async fn test_recycled() {
 
         cmd("CLIENT")
             .arg("ID")
-            .query_async::<_, i64>(&mut conn)
+            .query_async::<i64>(&mut conn)
             .await
             .unwrap()
     };
@@ -109,7 +109,7 @@ async fn test_recycled() {
 
         let new_client_id = cmd("CLIENT")
             .arg("ID")
-            .query_async::<_, i64>(&mut conn)
+            .query_async::<i64>(&mut conn)
             .await
             .unwrap();
 


### PR DESCRIPTION
Maybe bump a new version?