### PR TITLE
Add read_from_replicas method and environment variable support for Redis cluster configuration

### DIFF
--- a/r2d2/CHANGELOG.md
+++ b/r2d2/CHANGELOG.md
@@ -9,9 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- __Breaking:__ Modified the `Config` struct to support `read_from_replicas` for Redis clusters, using the redis-rs crate's functionality.
-- Added support for enabling `read_from_replicas` via the environment variable REDIS_CLUSTER__READ_FROM_REPLICAS.
-
 ## [0.4.1] - 2024-05-04
 
 - Update `deadpool` dependency to version `0.12`

--- a/r2d2/CHANGELOG.md
+++ b/r2d2/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- __Breaking:__ Modified the `Config` struct to support `read_from_replicas` for Redis clusters, using the redis-rs crate's functionality.
+- Added support for enabling `read_from_replicas` via the environment variable REDIS_CLUSTER__READ_FROM_REPLICAS.
+
 ## [0.4.1] - 2024-05-04
 
 - Update `deadpool` dependency to version `0.12`

--- a/redis/CHANGELOG.md
+++ b/redis/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- __Breaking:__ Modified the `Config` struct to support `read_from_replicas` for Redis clusters, using the redis-rs crate's functionality.
+- Added support for enabling `read_from_replicas` via the environment variable REDIS_CLUSTER__READ_FROM_REPLICAS.
+
 ## [0.16.0] - 2024-08-05
 
 - Update `redis` dependency to version `0.26`

--- a/redis/src/cluster/config.rs
+++ b/redis/src/cluster/config.rs
@@ -122,7 +122,6 @@ impl Config {
     /// Enables reading from replicas for the Redis cluster.
     ///
     /// This method sets `read_from_replicas` to `true`.
-    #[must_use]
     pub fn read_from_replicas(&mut self) {
         self.read_from_replicas = true;
     }

--- a/redis/src/cluster/config.rs
+++ b/redis/src/cluster/config.rs
@@ -118,13 +118,6 @@ impl Config {
             read_from_replicas: false,
         }
     }
-
-    /// Enables reading from replicas for the Redis cluster.
-    ///
-    /// This method sets `read_from_replicas` to `true`.
-    pub fn read_from_replicas(&mut self) {
-        self.read_from_replicas = true;
-    }
 }
 
 impl Default for Config {

--- a/redis/src/cluster/config.rs
+++ b/redis/src/cluster/config.rs
@@ -11,6 +11,7 @@ use super::{CreatePoolError, Pool, PoolBuilder, PoolConfig, Runtime};
 /// [`config`](https://crates.io/crates/config) crate as following:
 /// ```env
 /// REDIS_CLUSTER__URLS=redis://127.0.0.1:7000,redis://127.0.0.1:7001
+/// REDIS_CLUSTER__READ_FROM_REPLICAS=true
 /// REDIS_CLUSTER__POOL__MAX_SIZE=16
 /// REDIS_CLUSTER__POOL__TIMEOUTS__WAIT__SECS=2
 /// REDIS_CLUSTER__POOL__TIMEOUTS__WAIT__NANOS=0
@@ -48,6 +49,18 @@ pub struct Config {
 
     /// Pool configuration.
     pub pool: Option<PoolConfig>,
+
+    /// Enables or disables reading from replica nodes in a Redis cluster.
+    ///
+    /// When set to `true`, read operations may be distributed across
+    /// replica nodes, which can help in load balancing read requests.
+    /// When set to `false`, all read operations will be directed to the
+    /// master node(s). This option is particularly useful in a high-availability
+    /// setup where read scalability is needed.
+    ///
+    /// Default is `false`.
+    #[serde(default)]
+    pub read_from_replicas: bool,
 }
 
 impl Config {
@@ -71,11 +84,16 @@ impl Config {
     /// See [`ConfigError`] for details.
     pub fn builder(&self) -> Result<PoolBuilder, ConfigError> {
         let manager = match (&self.urls, &self.connections) {
-            (Some(urls), None) => {
-                super::Manager::new(urls.iter().map(|url| url.as_str()).collect())?
+            (Some(urls), None) => super::Manager::new(
+                urls.iter().map(|url| url.as_str()).collect(),
+                self.read_from_replicas,
+            )?,
+            (None, Some(connections)) => {
+                super::Manager::new(connections.clone(), self.read_from_replicas)?
             }
-            (None, Some(connections)) => super::Manager::new(connections.clone())?,
-            (None, None) => super::Manager::new(vec![ConnectionInfo::default()])?,
+            (None, None) => {
+                super::Manager::new(vec![ConnectionInfo::default()], self.read_from_replicas)?
+            }
             (Some(_), Some(_)) => return Err(ConfigError::UrlAndConnectionSpecified),
         };
         let pool_config = self.get_pool_config();
@@ -97,7 +115,16 @@ impl Config {
             urls: Some(urls.into()),
             connections: None,
             pool: None,
+            read_from_replicas: false,
         }
+    }
+
+    /// Enables reading from replicas for the Redis cluster.
+    ///
+    /// This method sets `read_from_replicas` to `true`.
+    #[must_use]
+    pub fn read_from_replicas(&mut self) {
+        self.read_from_replicas = true;
     }
 }
 
@@ -107,6 +134,7 @@ impl Default for Config {
             urls: None,
             connections: Some(vec![ConnectionInfo::default()]),
             pool: None,
+            read_from_replicas: false,
         }
     }
 }

--- a/redis/tests/redis_cluster.rs
+++ b/redis/tests/redis_cluster.rs
@@ -56,7 +56,7 @@ async fn test_pipeline() {
 async fn test_read_from_replicas() {
     use deadpool_redis::redis::pipe;
     let mut cfg = Config::from_env();
-    let _ = cfg.redis_cluster.read_from_replicas();
+    cfg.redis_cluster.read_from_replicas = true;
     assert_eq!(cfg.redis_cluster.read_from_replicas, true);
 
     let pool = cfg

--- a/redis/tests/redis_cluster.rs
+++ b/redis/tests/redis_cluster.rs
@@ -53,6 +53,31 @@ async fn test_pipeline() {
 }
 
 #[tokio::test]
+async fn test_read_from_replicas() {
+    use deadpool_redis::redis::pipe;
+    let mut cfg = Config::from_env();
+    let _ = cfg.redis_cluster.read_from_replicas();
+    assert_eq!(cfg.redis_cluster.read_from_replicas, true);
+
+    let pool = cfg
+        .redis_cluster
+        .create_pool(Some(Runtime::Tokio1))
+        .unwrap();
+    let mut conn = pool.get().await.unwrap();
+    let (value,): (String,) = pipe()
+        .cmd("SET")
+        .arg("deadpool/pipeline_test_key")
+        .arg("42")
+        .ignore()
+        .cmd("GET")
+        .arg("deadpool/pipeline_test_key")
+        .query_async(&mut conn)
+        .await
+        .unwrap();
+    assert_eq!(value, "42".to_string());
+}
+
+#[tokio::test]
 async fn test_high_level_commands() {
     use deadpool_redis::redis::AsyncCommands;
     let pool = create_pool();


### PR DESCRIPTION
## Overview

This PR introduces the following changes:
1. Added the `read_from_replicas` method to the `Config` struct for easier configuration.
   - The `read_from_replicas` method allows enabling read operations from Redis replica nodes in a more intuitive way.
2. Enabled reading the `REDIS_CLUSTER__READ_FROM_REPLICAS=true` environment variable for configuration.
   - The configuration now supports environment variables such as `REDIS_CLUSTER__READ_FROM_REPLICAS` for enabling or disabling reading from replicas.

## Changes
- Implemented the `read_from_replicas` method to simplify the process of enabling replica reads.
- Updated the configuration handling to support reading environment variables, specifically `REDIS_CLUSTER__READ_FROM_REPLICAS`.

## Testing
- Added a test to ensure that Redis write operations work correctly when `read_from_replicas` is enabled.
- Skipped testing whether read commands are actually sent to replicas, as this behavior is managed internally by `redis-rs`, and we rely on its implementation for this verification.

## Issue
This PR addresses issue #350.
