### PR TITLE
Export ProtocolVersion in the public interface

### DIFF
--- a/redis/src/lib.rs
+++ b/redis/src/lib.rs
@@ -41,7 +41,9 @@ use redis::{
 
 pub use redis;
 
-pub use self::config::{Config, ConfigError, ConnectionAddr, ConnectionInfo, RedisConnectionInfo};
+pub use self::config::{
+    Config, ConfigError, ConnectionAddr, ConnectionInfo, ProtocolVersion, RedisConnectionInfo,
+};
 
 pub use deadpool::managed::reexports::*;
 deadpool::managed_reexports!("redis", Manager, Connection, RedisError, ConfigError);


### PR DESCRIPTION
Exports the `ProtocolVersion` enum in the public interface allowing users to construct `ConnectionInfo` instances. Address #353 

If the decision to not export it was intentional, then I'll just close the issue and this PR.