### PR TITLE
Fix serde not in scope error.

### DIFF
--- a/redis/src/cluster/config.rs
+++ b/redis/src/cluster/config.rs
@@ -59,7 +59,7 @@ pub struct Config {
     /// setup where read scalability is needed.
     ///
     /// Default is `false`.
-    #[serde(default)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub read_from_replicas: bool,
 }
 


### PR DESCRIPTION
As serde is an optional dependency, the #[serde(default)] must be behind a cfg_attr to make sure it is only applied in case the serde feature is enabled.