### PR TITLE
Allow configuring Redis connections via AsyncConnectionConfig

### DIFF
--- a/redis/src/lib.rs
+++ b/redis/src/lib.rs
@@ -36,7 +36,7 @@ use std::{
 use deadpool::managed;
 use redis::{
     aio::{ConnectionLike, MultiplexedConnection},
-    Client, IntoConnectionInfo, RedisError, RedisResult,
+    AsyncConnectionConfig, Client, IntoConnectionInfo, RedisError, RedisResult,
 };
 
 pub use redis;
@@ -127,10 +127,20 @@ impl ConnectionLike for Connection {
 /// [`Manager`] for creating and recycling [`redis`] connections.
 ///
 /// [`Manager`]: managed::Manager
-#[derive(Debug)]
 pub struct Manager {
     client: Client,
     ping_number: AtomicUsize,
+    connection_config: AsyncConnectionConfig,
+}
+
+// `redis::AsyncConnectionConfig: !Debug`
+impl std::fmt::Debug for Manager {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Manager")
+            .field("client", &self.client)
+            .field("ping_number", &self.ping_number)
+            .finish()
+    }
 }
 
 impl Manager {
@@ -140,9 +150,22 @@ impl Manager {
     ///
     /// If establishing a new [`Client`] fails.
     pub fn new<T: IntoConnectionInfo>(params: T) -> RedisResult<Self> {
+        Self::from_config(params, AsyncConnectionConfig::default())
+    }
+
+    /// Creates a new [`Manager`] from the given `params` and [`AsyncConnectionConfig`].
+    ///
+    /// # Errors
+    ///
+    /// If establishing a new [`Client`] fails.
+    pub fn from_config<T: IntoConnectionInfo>(
+        params: T,
+        connection_config: AsyncConnectionConfig,
+    ) -> RedisResult<Self> {
         Ok(Self {
             client: Client::open(params)?,
             ping_number: AtomicUsize::new(0),
+            connection_config,
         })
     }
 }
@@ -152,7 +175,10 @@ impl managed::Manager for Manager {
     type Error = RedisError;
 
     async fn create(&self) -> Result<MultiplexedConnection, RedisError> {
-        let conn = self.client.get_multiplexed_async_connection().await?;
+        let conn = self
+            .client
+            .get_multiplexed_async_connection_with_config(&self.connection_config)
+            .await?;
         Ok(conn)
     }
 


### PR DESCRIPTION
Currently, deadpool-redis doesn't provide any way to modify the [`MultiplexedConnection`](https://docs.rs/redis/0.27.2/redis/aio/struct.MultiplexedConnection.html) configuration (e.g. to set connection or response timeouts).
This PR addresses this by implementing a new constructor for the `Manager`, `new_with_connection_config`, that lets the user provide an [`AsyncConnectionConfig`](https://docs.rs/redis/0.27.2/redis/struct.AsyncConnectionConfig.html) to the `Manager`, such that we can construct the connection via [`get_multiplexed_async_connection_with_config`](https://docs.rs/redis/0.27.2/redis/struct.Client.html#method.get_multiplexed_async_connection_with_config).

Please let me know if there's anything I have missed or if you'd rather this be done differently.