### PR TITLE
Update Cargo.toml

### DIFF
--- a/diesel/Cargo.toml
+++ b/diesel/Cargo.toml
@@ -29,8 +29,8 @@ deadpool = { path = "../", version = "0.12.0", default-features = false, feature
     "managed",
 ] }
 deadpool-sync = { path = "../sync", version = "0.1.1" }
-diesel = { version = "2.2.0", default-features = false }
+diesel = { version = "2.2.3", default-features = false }
 
 [dev-dependencies]
-diesel = { version = "2.2.0", default-features = false, features = ["sqlite"] }
+diesel = { version = "2.2.3", default-features = false, features = ["sqlite"] }
 tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread"] }


### PR DESCRIPTION
Bumps the dependency to at least 2.2.3 as per the advisory

[Advisory](https://rustsec.org/advisories/RUSTSEC-2024-0365.html)

(even though this crate may not be using the function mentioned in the advisory, it is better to bump it to ensure that there is no chance of other dependencies pulling it)