### PR TITLE
Fix panics on resize

### DIFF
--- a/src/managed/mod.rs
+++ b/src/managed/mod.rs
@@ -490,7 +490,7 @@ impl<M: Manager, W: From<Object<M>>> Pool<M, W> {
         }
         // grow pool
         if max_size > old_max_size {
-            let additional = slots.max_size - max_size;
+            let additional = slots.max_size - old_max_size;
             slots.vec.reserve_exact(additional);
             self.inner.semaphore.add_permits(additional);
         }

--- a/tests/managed.rs
+++ b/tests/managed.rs
@@ -108,16 +108,6 @@ async fn closing() {
     assert_eq!(pool.status().waiting, 0);
 }
 
-#[tokio::test]
-async fn close_resize() {
-    let mgr = Manager {};
-    let pool = Pool::builder(mgr).max_size(1).build().unwrap();
-    pool.close();
-    pool.resize(16);
-    assert_eq!(pool.status().size, 0);
-    assert_eq!(pool.status().max_size, 0);
-}
-
 #[tokio::test(flavor = "multi_thread")]
 async fn concurrent() {
     let mgr = Manager {};
@@ -192,93 +182,6 @@ async fn object_take() {
     assert_eq!(status.available, 2);
     assert_eq!(status.waiting, 0);
 }
-
-#[tokio::test]
-async fn resize_pool_shrink() {
-    let mgr = Manager {};
-    let pool = Pool::builder(mgr).max_size(2).build().unwrap();
-    let obj0 = pool.get().await.unwrap();
-    let obj1 = pool.get().await.unwrap();
-    pool.resize(1);
-    assert_eq!(pool.status().max_size, 1);
-    assert_eq!(pool.status().size, 2);
-    drop(obj1);
-    assert_eq!(pool.status().max_size, 1);
-    assert_eq!(pool.status().size, 1);
-    drop(obj0);
-    assert_eq!(pool.status().max_size, 1);
-    assert_eq!(pool.status().size, 1);
-}
-
-#[tokio::test]
-async fn resize_pool_grow() {
-    let mgr = Manager {};
-    let pool = Pool::builder(mgr).max_size(1).build().unwrap();
-    let obj0 = pool.get().await.unwrap();
-    pool.resize(2);
-    assert_eq!(pool.status().max_size, 2);
-    assert_eq!(pool.status().size, 1);
-    let obj1 = pool.get().await.unwrap();
-    assert_eq!(pool.status().max_size, 2);
-    assert_eq!(pool.status().size, 2);
-    drop(obj1);
-    assert_eq!(pool.status().max_size, 2);
-    assert_eq!(pool.status().size, 2);
-    drop(obj0);
-    assert_eq!(pool.status().max_size, 2);
-    assert_eq!(pool.status().size, 2);
-}
-
-#[tokio::test]
-async fn resize_pool_shrink_grow() {
-    let mgr = Manager {};
-    let pool = Pool::builder(mgr).max_size(1).build().unwrap();
-    let obj0 = pool.get().await.unwrap();
-    pool.resize(2);
-    pool.resize(0);
-    pool.resize(5);
-    assert_eq!(pool.status().max_size, 5);
-    assert_eq!(pool.status().size, 1);
-    drop(obj0);
-    assert_eq!(pool.status().max_size, 5);
-    assert_eq!(pool.status().size, 1);
-}
-
-#[tokio::test]
-async fn resize_pool_grow_concurrent() {
-    let mgr = Manager {};
-    let pool = Pool::builder(mgr).max_size(0).build().unwrap();
-    let join_handle = {
-        let pool = pool.clone();
-        tokio::spawn(async move { pool.get().await })
-    };
-    tokio::task::yield_now().await;
-    assert_eq!(pool.status().max_size, 0);
-    assert_eq!(pool.status().size, 0);
-    assert_eq!(pool.status().available, 0);
-    assert_eq!(pool.status().waiting, 1);
-    pool.resize(1);
-    assert_eq!(pool.status().max_size, 1);
-    assert_eq!(pool.status().size, 0);
-    assert_eq!(pool.status().available, 0);
-    assert_eq!(pool.status().waiting, 1);
-    tokio::task::yield_now().await;
-    assert_eq!(pool.status().max_size, 1);
-    assert_eq!(pool.status().size, 1);
-    assert_eq!(pool.status().available, 0);
-    assert_eq!(pool.status().waiting, 0);
-    let obj0 = join_handle.await.unwrap().unwrap();
-    assert_eq!(pool.status().max_size, 1);
-    assert_eq!(pool.status().size, 1);
-    assert_eq!(pool.status().available, 0);
-    assert_eq!(pool.status().waiting, 0);
-    drop(obj0);
-    assert_eq!(pool.status().max_size, 1);
-    assert_eq!(pool.status().size, 1);
-    assert_eq!(pool.status().available, 1);
-    assert_eq!(pool.status().waiting, 0);
-}
-
 #[tokio::test]
 async fn retain() {
     let mgr = Manager {};

--- a/tests/managed_resize.rs
+++ b/tests/managed_resize.rs
@@ -21,6 +21,7 @@ impl managed::Manager for Manager {
     }
 }
 
+// Regression test for https://github.com/bikeshedder/deadpool/issues/380
 #[tokio::test]
 async fn test_grow_reuse_existing() {
     // Shrink doesn't discard objects currently borrowed from the pool but
@@ -48,4 +49,101 @@ async fn test_grow_reuse_existing() {
     drop(obj2);
     assert!(pool.status().size == 1);
     assert!(pool.status().max_size == 1);
+}
+
+
+#[tokio::test]
+async fn resize_pool_shrink() {
+    let mgr = Manager {};
+    let pool = Pool::builder(mgr).max_size(2).build().unwrap();
+    let obj0 = pool.get().await.unwrap();
+    let obj1 = pool.get().await.unwrap();
+    pool.resize(1);
+    assert_eq!(pool.status().max_size, 1);
+    assert_eq!(pool.status().size, 2);
+    drop(obj1);
+    assert_eq!(pool.status().max_size, 1);
+    assert_eq!(pool.status().size, 1);
+    drop(obj0);
+    assert_eq!(pool.status().max_size, 1);
+    assert_eq!(pool.status().size, 1);
+}
+
+#[tokio::test]
+async fn resize_pool_grow() {
+    let mgr = Manager {};
+    let pool = Pool::builder(mgr).max_size(1).build().unwrap();
+    let obj0 = pool.get().await.unwrap();
+    pool.resize(2);
+    assert_eq!(pool.status().max_size, 2);
+    assert_eq!(pool.status().size, 1);
+    let obj1 = pool.get().await.unwrap();
+    assert_eq!(pool.status().max_size, 2);
+    assert_eq!(pool.status().size, 2);
+    drop(obj1);
+    assert_eq!(pool.status().max_size, 2);
+    assert_eq!(pool.status().size, 2);
+    drop(obj0);
+    assert_eq!(pool.status().max_size, 2);
+    assert_eq!(pool.status().size, 2);
+}
+
+#[tokio::test]
+async fn resize_pool_shrink_grow() {
+    let mgr = Manager {};
+    let pool = Pool::builder(mgr).max_size(1).build().unwrap();
+    let obj0 = pool.get().await.unwrap();
+    pool.resize(2);
+    pool.resize(0);
+    pool.resize(5);
+    assert_eq!(pool.status().max_size, 5);
+    assert_eq!(pool.status().size, 1);
+    drop(obj0);
+    assert_eq!(pool.status().max_size, 5);
+    assert_eq!(pool.status().size, 1);
+}
+
+#[tokio::test]
+async fn resize_pool_grow_concurrent() {
+    let mgr = Manager {};
+    let pool = Pool::builder(mgr).max_size(0).build().unwrap();
+    let join_handle = {
+        let pool = pool.clone();
+        tokio::spawn(async move { pool.get().await })
+    };
+    tokio::task::yield_now().await;
+    assert_eq!(pool.status().max_size, 0);
+    assert_eq!(pool.status().size, 0);
+    assert_eq!(pool.status().available, 0);
+    assert_eq!(pool.status().waiting, 1);
+    pool.resize(1);
+    assert_eq!(pool.status().max_size, 1);
+    assert_eq!(pool.status().size, 0);
+    assert_eq!(pool.status().available, 0);
+    assert_eq!(pool.status().waiting, 1);
+    tokio::task::yield_now().await;
+    assert_eq!(pool.status().max_size, 1);
+    assert_eq!(pool.status().size, 1);
+    assert_eq!(pool.status().available, 0);
+    assert_eq!(pool.status().waiting, 0);
+    let obj0 = join_handle.await.unwrap().unwrap();
+    assert_eq!(pool.status().max_size, 1);
+    assert_eq!(pool.status().size, 1);
+    assert_eq!(pool.status().available, 0);
+    assert_eq!(pool.status().waiting, 0);
+    drop(obj0);
+    assert_eq!(pool.status().max_size, 1);
+    assert_eq!(pool.status().size, 1);
+    assert_eq!(pool.status().available, 1);
+    assert_eq!(pool.status().waiting, 0);
+}
+
+#[tokio::test]
+async fn close_resize() {
+    let mgr = Manager {};
+    let pool = Pool::builder(mgr).max_size(1).build().unwrap();
+    pool.close();
+    pool.resize(16);
+    assert_eq!(pool.status().size, 0);
+    assert_eq!(pool.status().max_size, 0);
 }


### PR DESCRIPTION
_(As I don't have write access to the Deadpool repo directly, I had to continue on #382 by creating a new PR on my fork)_

@bikeshedder I believe the cause of the broken tests was that you used `max_size` rather than `old_max_size` in the fix. Probably just a typo.

This PR:
- [x] Fixes that typo
- [x] Moves all resizing-related tests to the same testing submodule
- [x] Mentions the issue that the new test is a regression test for in the new test's comments.