### PR TITLE
chore: Bump rusqlite 0.32.1 -> 0.33.0

### DIFF
--- a/sqlite/Cargo.toml
+++ b/sqlite/Cargo.toml
@@ -26,7 +26,7 @@ deadpool = { path = "../", version = "0.12.0", default-features = false, feature
     "managed",
 ] }
 deadpool-sync = { path = "../sync", version = "0.1.1" }
-rusqlite = "0.32.1"
+rusqlite = "0.33.0"
 serde = { package = "serde", version = "1.0", features = [
     "derive",
 ], optional = true }

--- a/sqlite/Cargo.toml
+++ b/sqlite/Cargo.toml
@@ -2,7 +2,7 @@
 name = "deadpool-sqlite"
 version = "0.9.0"
 edition = "2021"
-rust-version = "1.77"
+rust-version = "1.80"
 authors = ["Michael P. Jung <michael.jung@terreon.de>"]
 description = "Dead simple async pool for rusqlite"
 keywords = ["async", "database", "pool", "sqlite"]


### PR DESCRIPTION
I ran `deadpool-sqlite`'s tests, and it seems to all pass. Had to bump MSRV due to `LazyLock` usage. Please advise if there's anything left to do. 😄 