### PR TITLE
Allow providing TlsCertificates when creating a redis Manager

### DIFF
--- a/crates/deadpool-redis/src/lib.rs
+++ b/crates/deadpool-redis/src/lib.rs
@@ -145,6 +145,22 @@ impl Manager {
             ping_number: AtomicUsize::new(0),
         })
     }
+
+    /// Creates a new [`Manager`] from the given `params` and TLS certificates.`
+    ///
+    /// # Errors
+    ///
+    /// If establishing a new [`Client`] fails.
+    #[cfg(feature = "tls-rustls")]
+    pub fn from_tls_certificates<T: IntoConnectionInfo>(
+        params: T,
+        tls_certs: redis::TlsCertificates,
+    ) -> RedisResult<Self> {
+        Ok(Self {
+            client: Client::build_with_tls(params, tls_certs)?,
+            ping_number: AtomicUsize::new(0),
+        })
+    }
 }
 
 impl managed::Manager for Manager {


### PR DESCRIPTION
This PR makes it possible to use TLS with `deadpool_redis` by providing the `TlsCertificates` instance when creating a Manager. 

An alternative would be to make it possible to create a `Manager` directly from a `Client`. However, to me it looks like providing the `TlsCertificates` aligns better with what other deadpool crates do.

The original issue (#404) also suggests that `deadpool_redis::Config` could have a `tls_params` field.
This appears to be tricky, as the `TlsConnParams` struct is not exposed directly by the `redis` crate.

Closes #404.