### PR TITLE
fix(sqlite): Remove a double call to `PoolBuilder::runtime`

### DIFF
--- a/crates/deadpool-sqlite/src/config.rs
+++ b/crates/deadpool-sqlite/src/config.rs
@@ -56,7 +56,6 @@ impl Config {
     pub fn create_pool(&self, runtime: Runtime) -> Result<Pool, CreatePoolError> {
         self.builder(runtime)
             .map_err(CreatePoolError::Config)?
-            .runtime(runtime)
             .build()
             .map_err(CreatePoolError::Build)
     }


### PR DESCRIPTION
This patch removes a double call to `PoolBuilder::runtime` in `Config::create_pool`.

Indeed, `Config::create_pool` calls `Config::builder` which sets the given `runtime` to the `PoolBuilder` by calling `PoolBuilder::runtime`. Then, once `Config::builder` has returned, `Config::create_pool` calls `PoolBuilder::runtime` again. This second call is useless as `runtime` is still the same unchanged value. This patch removes this second call.