### PR TITLE
deadpool-redis: Re-export the `uuid` feature of the `redis` crate.

### DIFF
--- a/crates/deadpool-redis/Cargo.toml
+++ b/crates/deadpool-redis/Cargo.toml
@@ -53,6 +53,7 @@ cache-aio = ["redis/cache-aio"]
 smol-comp = ["redis/smol-comp"]
 smol-native-tls-comp = ["redis/smol-native-tls-comp"]
 smol-rustls-comp = ["redis/smol-rustls-comp"]
+uuid = ["redis/uuid"]
 
 [dependencies]
 deadpool = { path = "../deadpool", version = "0.12.0", default-features = false, features = [


### PR DESCRIPTION
The [docs](https://docs.rs/deadpool-redis/latest/deadpool_redis/) state that:

    All of the features of [redis](https://crates.io/crates/redis) are also re-exported.

Seem to have missed this one, or the docs are inaccurate.