### PR TITLE
fix: Fix a panic when calling `JoinError::into_panic`

### DIFF
--- a/crates/deadpool-runtime/Cargo.toml
+++ b/crates/deadpool-runtime/Cargo.toml
@@ -35,3 +35,6 @@ tokio_1 = { package = "tokio", version = "1.0", features = [
     "time",
     "rt",
 ], optional = true }
+
+[dev-dependencies]
+tokio_1 = { package = "tokio", version = "1.0", features = ["rt", "macros"] }


### PR DESCRIPTION
That's a lot of panics. This patch fixes a panic raised by `JoinError:into_panic` when the `JoinError` represents a cancellation instead of a panic.

---

* Fix https://github.com/deadpool-rs/deadpool/issues/460