### PR TITLE
Add AsyncConnectionConfig support to Manager

### DIFF
--- a/crates/deadpool-redis/src/lib.rs
+++ b/crates/deadpool-redis/src/lib.rs
@@ -35,7 +35,7 @@ use std::{
 
 use deadpool::managed;
 use redis::{
-    Client, IntoConnectionInfo, RedisError, RedisResult,
+    AsyncConnectionConfig, Client, IntoConnectionInfo, RedisError, RedisResult,
     aio::{ConnectionLike, MultiplexedConnection},
 };
 
@@ -127,10 +127,19 @@ impl ConnectionLike for Connection {
 /// [`Manager`] for creating and recycling [`redis`] connections.
 ///
 /// [`Manager`]: managed::Manager
-#[derive(Debug)]
 pub struct Manager {
     client: Client,
+    connection_config: Option<AsyncConnectionConfig>,
     ping_number: AtomicUsize,
+}
+
+impl std::fmt::Debug for Manager {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Manager")
+            .field("client", &self.client)
+            .field("ping_number", &self.ping_number)
+            .finish()
+    }
 }
 
 impl Manager {
@@ -142,6 +151,27 @@ impl Manager {
     pub fn new<T: IntoConnectionInfo>(params: T) -> RedisResult<Self> {
         Ok(Self {
             client: Client::open(params)?,
+            connection_config: None,
+            ping_number: AtomicUsize::new(0),
+        })
+    }
+
+    /// Creates a new [`Manager`] from the given `params` and
+    /// [`AsyncConnectionConfig`].
+    ///
+    /// This allows configuring connection-level settings such as response timeouts and connection
+    /// timeouts.
+    ///
+    /// # Errors
+    ///
+    /// If establishing a new [`Client`] fails.
+    pub fn new_with_config<T: IntoConnectionInfo>(
+        params: T,
+        connection_config: AsyncConnectionConfig,
+    ) -> RedisResult<Self> {
+        Ok(Self {
+            client: Client::open(params)?,
+            connection_config: Some(connection_config),
             ping_number: AtomicUsize::new(0),
         })
     }
@@ -152,7 +182,15 @@ impl managed::Manager for Manager {
     type Error = RedisError;
 
     async fn create(&self) -> Result<MultiplexedConnection, RedisError> {
-        let conn = self.client.get_multiplexed_async_connection().await?;
+        let conn = match &self.connection_config {
+            Some(config) => {
+                self.client
+                    .get_multiplexed_async_connection_with_config(config)
+                    .await?
+            }
+            None => self.client.get_multiplexed_async_connection().await?,
+        };
+
         Ok(conn)
     }
 

--- a/crates/deadpool-redis/tests/redis_connection_config.rs
+++ b/crates/deadpool-redis/tests/redis_connection_config.rs
@@ -1,0 +1,89 @@
+#![cfg(feature = "serde")]
+
+use std::time::Duration;
+
+use deadpool_redis::{Manager, Pool, Runtime};
+use redis::{AsyncCommands, AsyncConnectionConfig};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Default, Deserialize, Serialize)]
+struct Config {
+    #[serde(default)]
+    redis: deadpool_redis::Config,
+}
+
+impl Config {
+    pub fn from_env() -> Self {
+        config::Config::builder()
+            .add_source(config::Environment::default().separator("__"))
+            .build()
+            .unwrap()
+            .try_deserialize()
+            .unwrap()
+    }
+}
+
+fn redis_url() -> String {
+    Config::from_env().redis.url.unwrap_or_default()
+}
+
+fn create_pool_with_config(connection_config: AsyncConnectionConfig) -> Pool {
+    let manager = Manager::new_with_config(redis_url(), connection_config).unwrap();
+    Pool::builder(manager)
+        .max_size(1)
+        .runtime(Runtime::Tokio1)
+        .build()
+        .unwrap()
+}
+
+fn create_pool_default() -> Pool {
+    let manager = Manager::new(redis_url()).unwrap();
+    Pool::builder(manager)
+        .max_size(1)
+        .runtime(Runtime::Tokio1)
+        .build()
+        .unwrap()
+}
+
+/// Verifies that `new_with_config` with `set_response_timeout(None)` allows commands that take
+/// longer than the default 500ms timeout.
+///
+/// Uses `BLPOP` on an empty list with a 1-second timeout. With the default `AsyncConnectionConfig`
+/// (500ms response timeout), this would fail. With `set_response_timeout(None)`, it waits the full
+/// second and returns nil.
+#[tokio::test]
+async fn test_response_timeout_can_be_disabled() {
+    let config = AsyncConnectionConfig::new().set_response_timeout(None);
+    let pool = create_pool_with_config(config);
+    let mut conn = pool.get().await.unwrap();
+
+    let result: Option<(String, String)> = conn
+        .blpop("deadpool/nonexistent_timeout_test_key", 1.0)
+        .await
+        .unwrap();
+    assert_eq!(result, None);
+}
+
+/// Verifies that the default `Manager::new` (without config) uses the redis crate's default
+/// timeouts, which causes blocking commands exceeding 500ms to fail.
+#[tokio::test]
+async fn test_default_manager_times_out_on_slow_commands() {
+    let pool = create_pool_default();
+    let mut conn = pool.get().await.unwrap();
+
+    let start = std::time::Instant::now();
+    let result: Result<Option<(String, String)>, _> = conn
+        .blpop("deadpool/nonexistent_default_timeout_key", 1.0)
+        .await;
+    let elapsed = start.elapsed();
+
+    assert!(
+        result.is_err(),
+        "expected timeout error with default config"
+    );
+    assert!(
+        elapsed < Duration::from_millis(900),
+        "should have timed out before the 1s BLPOP completed, took {:?}",
+        elapsed
+    );
+}


### PR DESCRIPTION
Add `Manager::new_with_config` which accepts an `AsyncConnectionConfig`, allowing connection-level settings (e.g. response timeout, connection timeout) to be configured when creating pooled connections.

The existing `Manager::new` behavior is unchanged. When a config is provided, `get_multiplexed_async_connection_with_config` is used instead of `get_multiplexed_async_connection`.

Relates to #452 (you can set timeout on `AsyncConnectionConfig`)

---

Before Redis 1 we only get a response timeout [when it was explicitly set](https://github.com/redis-rs/redis-rs/blob/193f51771e545e9ade61cf756b269511af5de046/redis/src/client.rs#L205-L209), probably via any of the constructors such as [`get_multiplexed_async_connection_with_timeouts`](https://github.com/redis-rs/redis-rs/blob/193f51771e545e9ade61cf756b269511af5de046/redis/src/client.rs#L307)

With version 1, we now get a [default of 500ms](https://github.com/redis-rs/redis-rs/blob/3ebba95c86417a1c36c7881866ed427e74feda76/redis/src/client.rs#L178) if no `AsyncConnectionConfig` is passed.

Since we can't pass this through `deadpool-redis`, we'll always end up with an initial 500ms and to change that we'll do something like

```rust
let mut conn = pool.get().await?;
conn.set_response_timeout(Duration::from_secs(300));
```

That's also not fully compatible because `set_response_timeout` still doesn't accept `None` which is a valid value.