### PR TITLE
fix devcontainer failed to start

### DIFF
--- a/.devcontainer/.dockerignore
+++ b/.devcontainer/.dockerignore
@@ -1,0 +1,7 @@
+.env
+compose.yml
+devcontainer.json
+Dockerfile
+postgres.env
+rabbitmq.env
+post-create.sh

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -17,6 +17,3 @@ USER vscode
 
 ARG RUST_VERSION
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain ${RUST_VERSION} --no-modify-path -y
-
-RUN /home/vscode/.cargo/bin/cargo install cargo-release
-RUN /home/vscode/.cargo/bin/cargo install --locked cargo-outdated

--- a/.devcontainer/compose.yml
+++ b/.devcontainer/compose.yml
@@ -51,7 +51,7 @@ services:
 
   redis-sentinel:
     # https://hub.docker.com/r/bitnami/redis-sentinel
-    image: bitnami/redis-sentinel:7.4
+    image: bitnami/redis-sentinel:latest
     environment:
       ALLOW_EMPTY_PASSWORD: yes
     volumes:

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,6 +5,7 @@
   "dockerComposeFile": "compose.yml",
   "service": "app",
   "workspaceFolder": "/workspace",
+  "postCreateCommand": ["/bin/bash", "./.devcontainer/post-create.sh"],
   // Configure tool-specific properties.
   "customizations": {
     // Configure properties specific to VS Code.

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+cargo install cargo-release
+cargo install --locked cargo-outdated

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 cargo install cargo-release
 cargo install --locked cargo-outdated


### PR DESCRIPTION
Fix the devcontainer failing to start in Codespaces and improve build performance.

Changes:

* Fix `redis-sentinel` image tag in `docker-compose`
* Move `cargo-release` and `cargo-outdated` installation to `postCreateCommand`
* Add `.dockerignore` to avoid unnecessary full Docker rebuilds

Closes #476
