### PR TITLE
Replace `num_cpus` with `std::thread::available_parallelism`

### DIFF
--- a/crates/deadpool/CHANGELOG.md
+++ b/crates/deadpool/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Remove `num_cpus` dependency
+
 ## [0.13.0] - 2026-02-17
 
 - Update `deadpool-runtime` dependency to version 0.3

--- a/crates/deadpool/Cargo.toml
+++ b/crates/deadpool/Cargo.toml
@@ -23,7 +23,6 @@ rt_async-std_1 = ["deadpool-runtime/async-std_1"]
 rt_smol_2 = ["deadpool-runtime/smol_2"]
 
 [dependencies]
-num_cpus = "1.11.1"
 # `serde` feature
 serde = { version = "1.0.103", features = ["derive"], optional = true }
 # `rt_async-std_1` feature

--- a/crates/deadpool/src/util.rs
+++ b/crates/deadpool/src/util.rs
@@ -1,9 +1,13 @@
-use std::sync::LazyLock;
+use std::{num::NonZeroUsize, sync::LazyLock};
 
-/// Cache the physical CPU cofunt to avoid calling `num_cpus::get()`
-/// multiple times, which is expensive when creating pools in quick
-/// succession.
-static CPU_COUNT: LazyLock<usize> = LazyLock::new(num_cpus::get);
+/// Cache the logical CPU count to avoid calling
+/// `std::thread::available_parallelism()` multiple times, which is
+/// expensive when creating pools in quick succession.
+static CPU_COUNT: LazyLock<usize> = LazyLock::new(|| {
+    std::thread::available_parallelism()
+        .map(NonZeroUsize::get)
+        .unwrap_or(1)
+});
 
 /// Get the default maximum size of a pool, which is `cpu_core_count * 2`
 /// including logical cores (Hyper-Threading).


### PR DESCRIPTION
Makes use of `std::thread::available_parallelism` instead of needing the external `num_cpus::get`. There's some minor differences in behavior between the two, but nothing substantial, both report logical CPU count in practice.

For context, [`tokio`](https://github.com/tokio-rs/tokio/pull/6709) and [`futures`](https://github.com/rust-lang/futures-rs/pull/2946) have made the same switch in the past.
