### PR TITLE
Fix CI generation, resolve all CI issues

### DIFF
--- a/.github/workflows/deadpool-diesel.yml
+++ b/.github/workflows/deadpool-diesel.yml
@@ -3,16 +3,15 @@ defaults:
     working-directory: ./crates/deadpool-diesel
 env:
   RUST_BACKTRACE: 1
-permissions: {}
 jobs:
   check-integration:
     name: Check integration
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           components: rustc,rust-std,cargo
           toolchain: stable
@@ -44,24 +43,24 @@ jobs:
     name: Check re-exported features
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           components: rustc,rust-std,cargo
           toolchain: stable
-      - uses: dcarbone/install-jq-action@b7ef57d46ece78760b4019dbc4080a1ba2a40b45 # v3.2.0
-      - uses: dcarbone/install-yq-action@4075b4dca348d74bd83f2bf82d30f25d7c54539b # v1.3.1
+      - uses: dcarbone/install-jq-action@b7ef57d46ece78760b4019dbc4080a1ba2a40b45
+      - uses: dcarbone/install-yq-action@4075b4dca348d74bd83f2bf82d30f25d7c54539b
       - run: ../../tools/check-reexported-features.sh
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           components: rustc,rust-std,cargo,clippy
           toolchain: stable
@@ -70,14 +69,14 @@ jobs:
     name: MSRV
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           components: rustc,rust-std,cargo
           toolchain: nightly
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           components: rustc,rust-std,cargo
           toolchain: "1.85"
@@ -87,10 +86,10 @@ jobs:
     name: Doc
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           components: rustc,rust-std,cargo
           toolchain: stable
@@ -99,10 +98,10 @@ jobs:
     name: rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           components: rustc,rust-std,cargo,rustfmt
           toolchain: stable
@@ -112,10 +111,10 @@ jobs:
     runs-on: ubuntu-latest
     services: {}
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           components: rustc,rust-std,cargo
           toolchain: stable
@@ -137,3 +136,4 @@ name: deadpool-diesel
       - .github/workflows/deadpool-diesel.yml
     tags:
       - deadpool-diesel-v*
+permissions: {}

--- a/.github/workflows/deadpool-diesel.yml
+++ b/.github/workflows/deadpool-diesel.yml
@@ -2,6 +2,7 @@ defaults:
   run:
     working-directory: ./crates/deadpool-diesel
 env:
+  CARGO_NET_RETRY: 10
   RUST_BACKTRACE: 1
 jobs:
   check-integration:

--- a/.github/workflows/deadpool-lapin.yml
+++ b/.github/workflows/deadpool-lapin.yml
@@ -3,16 +3,15 @@ defaults:
     working-directory: ./crates/deadpool-lapin
 env:
   RUST_BACKTRACE: 1
-permissions: {}
 jobs:
   check-integration:
     name: Check integration
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           components: rustc,rust-std,cargo
           toolchain: stable
@@ -31,24 +30,24 @@ jobs:
     name: Check re-exported features
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           components: rustc,rust-std,cargo
           toolchain: stable
-      - uses: dcarbone/install-jq-action@b7ef57d46ece78760b4019dbc4080a1ba2a40b45 # v3.2.0
-      - uses: dcarbone/install-yq-action@4075b4dca348d74bd83f2bf82d30f25d7c54539b # v1.3.1
+      - uses: dcarbone/install-jq-action@b7ef57d46ece78760b4019dbc4080a1ba2a40b45
+      - uses: dcarbone/install-yq-action@4075b4dca348d74bd83f2bf82d30f25d7c54539b
       - run: ../../tools/check-reexported-features.sh
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           components: rustc,rust-std,cargo,clippy
           toolchain: stable
@@ -57,14 +56,14 @@ jobs:
     name: MSRV
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           components: rustc,rust-std,cargo
           toolchain: nightly
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           components: rustc,rust-std,cargo
           toolchain: "1.88"
@@ -74,10 +73,10 @@ jobs:
     name: Doc
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           components: rustc,rust-std,cargo
           toolchain: stable
@@ -86,10 +85,10 @@ jobs:
     name: rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           components: rustc,rust-std,cargo,rustfmt
           toolchain: stable
@@ -107,10 +106,10 @@ jobs:
         ports:
           - 5672:5672
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           components: rustc,rust-std,cargo
           toolchain: stable
@@ -133,3 +132,4 @@ name: deadpool-lapin
       - .github/workflows/deadpool-lapin.yml
     tags:
       - deadpool-lapin-v*
+permissions: {}

--- a/.github/workflows/deadpool-lapin.yml
+++ b/.github/workflows/deadpool-lapin.yml
@@ -2,6 +2,7 @@ defaults:
   run:
     working-directory: ./crates/deadpool-lapin
 env:
+  CARGO_NET_RETRY: 10
   RUST_BACKTRACE: 1
 jobs:
   check-integration:

--- a/.github/workflows/deadpool-libsql.yml
+++ b/.github/workflows/deadpool-libsql.yml
@@ -3,16 +3,15 @@ defaults:
     working-directory: ./crates/deadpool-libsql
 env:
   RUST_BACKTRACE: 1
-permissions: {}
 jobs:
   check-integration:
     name: Check integration
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           components: rustc,rust-std,cargo
           toolchain: stable
@@ -33,24 +32,24 @@ jobs:
     name: Check re-exported features
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           components: rustc,rust-std,cargo
           toolchain: stable
-      - uses: dcarbone/install-jq-action@b7ef57d46ece78760b4019dbc4080a1ba2a40b45 # v3.2.0
-      - uses: dcarbone/install-yq-action@4075b4dca348d74bd83f2bf82d30f25d7c54539b # v1.3.1
+      - uses: dcarbone/install-jq-action@b7ef57d46ece78760b4019dbc4080a1ba2a40b45
+      - uses: dcarbone/install-yq-action@4075b4dca348d74bd83f2bf82d30f25d7c54539b
       - run: ../../tools/check-reexported-features.sh
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           components: rustc,rust-std,cargo,clippy
           toolchain: stable
@@ -59,14 +58,14 @@ jobs:
     name: MSRV
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           components: rustc,rust-std,cargo
           toolchain: nightly
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           components: rustc,rust-std,cargo
           toolchain: "1.85"
@@ -76,10 +75,10 @@ jobs:
     name: Doc
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           components: rustc,rust-std,cargo
           toolchain: stable
@@ -88,10 +87,10 @@ jobs:
     name: rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           components: rustc,rust-std,cargo,rustfmt
           toolchain: stable
@@ -101,10 +100,10 @@ jobs:
     runs-on: ubuntu-latest
     services: {}
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           components: rustc,rust-std,cargo
           toolchain: stable
@@ -126,3 +125,4 @@ name: deadpool-libsql
       - .github/workflows/deadpool-libsql.yml
     tags:
       - deadpool-libsql-v*
+permissions: {}

--- a/.github/workflows/deadpool-libsql.yml
+++ b/.github/workflows/deadpool-libsql.yml
@@ -2,6 +2,7 @@ defaults:
   run:
     working-directory: ./crates/deadpool-libsql
 env:
+  CARGO_NET_RETRY: 10
   RUST_BACKTRACE: 1
 jobs:
   check-integration:

--- a/.github/workflows/deadpool-memcached.yml
+++ b/.github/workflows/deadpool-memcached.yml
@@ -3,30 +3,29 @@ defaults:
     working-directory: ./crates/deadpool-memcached
 env:
   RUST_BACKTRACE: 1
-permissions: {}
 jobs:
   check-reexported-features:
     name: Check re-exported features
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           components: rustc,rust-std,cargo
           toolchain: stable
-      - uses: dcarbone/install-jq-action@b7ef57d46ece78760b4019dbc4080a1ba2a40b45 # v3.2.0
-      - uses: dcarbone/install-yq-action@4075b4dca348d74bd83f2bf82d30f25d7c54539b # v1.3.1
+      - uses: dcarbone/install-jq-action@b7ef57d46ece78760b4019dbc4080a1ba2a40b45
+      - uses: dcarbone/install-yq-action@4075b4dca348d74bd83f2bf82d30f25d7c54539b
       - run: ../../tools/check-reexported-features.sh
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           components: rustc,rust-std,cargo,clippy
           toolchain: stable
@@ -35,14 +34,14 @@ jobs:
     name: MSRV
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           components: rustc,rust-std,cargo
           toolchain: nightly
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           components: rustc,rust-std,cargo
           toolchain: "1.85"
@@ -52,10 +51,10 @@ jobs:
     name: Doc
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           components: rustc,rust-std,cargo
           toolchain: stable
@@ -64,10 +63,10 @@ jobs:
     name: rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           components: rustc,rust-std,cargo,rustfmt
           toolchain: stable
@@ -81,10 +80,10 @@ jobs:
         ports:
           - 11211:11211
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           components: rustc,rust-std,cargo
           toolchain: stable
@@ -107,3 +106,4 @@ name: deadpool-memcached
       - .github/workflows/deadpool-memcached.yml
     tags:
       - deadpool-memcached-v*
+permissions: {}

--- a/.github/workflows/deadpool-memcached.yml
+++ b/.github/workflows/deadpool-memcached.yml
@@ -2,6 +2,7 @@ defaults:
   run:
     working-directory: ./crates/deadpool-memcached
 env:
+  CARGO_NET_RETRY: 10
   RUST_BACKTRACE: 1
 jobs:
   check-reexported-features:

--- a/.github/workflows/deadpool-postgres.yml
+++ b/.github/workflows/deadpool-postgres.yml
@@ -3,16 +3,15 @@ defaults:
     working-directory: ./crates/deadpool-postgres
 env:
   RUST_BACKTRACE: 1
-permissions: {}
 jobs:
   check-integration:
     name: Check integration
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           components: rustc,rust-std,cargo
           toolchain: stable
@@ -31,10 +30,10 @@ jobs:
     name: Check integration (WebAssembly)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           components: rustc,rust-std,cargo
           targets: wasm32-unknown-unknown
@@ -50,24 +49,24 @@ jobs:
     name: Check re-exported features
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           components: rustc,rust-std,cargo
           toolchain: stable
-      - uses: dcarbone/install-jq-action@b7ef57d46ece78760b4019dbc4080a1ba2a40b45 # v3.2.0
-      - uses: dcarbone/install-yq-action@4075b4dca348d74bd83f2bf82d30f25d7c54539b # v1.3.1
+      - uses: dcarbone/install-jq-action@b7ef57d46ece78760b4019dbc4080a1ba2a40b45
+      - uses: dcarbone/install-yq-action@4075b4dca348d74bd83f2bf82d30f25d7c54539b
       - run: ../../tools/check-reexported-features.sh
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           components: rustc,rust-std,cargo,clippy
           toolchain: stable
@@ -76,14 +75,14 @@ jobs:
     name: MSRV
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           components: rustc,rust-std,cargo
           toolchain: nightly
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           components: rustc,rust-std,cargo
           toolchain: "1.85"
@@ -93,10 +92,10 @@ jobs:
     name: Doc
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           components: rustc,rust-std,cargo
           toolchain: stable
@@ -105,10 +104,10 @@ jobs:
     name: rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           components: rustc,rust-std,cargo,rustfmt
           toolchain: stable
@@ -127,10 +126,10 @@ jobs:
         ports:
           - 5432:5432
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           components: rustc,rust-std,cargo
           toolchain: stable
@@ -157,3 +156,4 @@ name: deadpool-postgres
       - .github/workflows/deadpool-postgres.yml
     tags:
       - deadpool-postgres-v*
+permissions: {}

--- a/.github/workflows/deadpool-postgres.yml
+++ b/.github/workflows/deadpool-postgres.yml
@@ -2,6 +2,7 @@ defaults:
   run:
     working-directory: ./crates/deadpool-postgres
 env:
+  CARGO_NET_RETRY: 10
   RUST_BACKTRACE: 1
 jobs:
   check-integration:

--- a/.github/workflows/deadpool-r2d2.yml
+++ b/.github/workflows/deadpool-r2d2.yml
@@ -3,16 +3,15 @@ defaults:
     working-directory: ./crates/deadpool-r2d2
 env:
   RUST_BACKTRACE: 1
-permissions: {}
 jobs:
   check-integration:
     name: Check integration
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           components: rustc,rust-std,cargo
           toolchain: stable
@@ -32,24 +31,24 @@ jobs:
     name: Check re-exported features
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           components: rustc,rust-std,cargo
           toolchain: stable
-      - uses: dcarbone/install-jq-action@b7ef57d46ece78760b4019dbc4080a1ba2a40b45 # v3.2.0
-      - uses: dcarbone/install-yq-action@4075b4dca348d74bd83f2bf82d30f25d7c54539b # v1.3.1
+      - uses: dcarbone/install-jq-action@b7ef57d46ece78760b4019dbc4080a1ba2a40b45
+      - uses: dcarbone/install-yq-action@4075b4dca348d74bd83f2bf82d30f25d7c54539b
       - run: ../../tools/check-reexported-features.sh
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           components: rustc,rust-std,cargo,clippy
           toolchain: stable
@@ -58,14 +57,14 @@ jobs:
     name: MSRV
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           components: rustc,rust-std,cargo
           toolchain: nightly
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           components: rustc,rust-std,cargo
           toolchain: "1.85"
@@ -75,10 +74,10 @@ jobs:
     name: Doc
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           components: rustc,rust-std,cargo
           toolchain: stable
@@ -87,10 +86,10 @@ jobs:
     name: rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           components: rustc,rust-std,cargo,rustfmt
           toolchain: stable
@@ -109,10 +108,10 @@ jobs:
         ports:
           - 5432:5432
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           components: rustc,rust-std,cargo
           toolchain: stable
@@ -139,3 +138,4 @@ name: deadpool-r2d2
       - .github/workflows/deadpool-r2d2.yml
     tags:
       - deadpool-r2d2-v*
+permissions: {}

--- a/.github/workflows/deadpool-r2d2.yml
+++ b/.github/workflows/deadpool-r2d2.yml
@@ -2,6 +2,7 @@ defaults:
   run:
     working-directory: ./crates/deadpool-r2d2
 env:
+  CARGO_NET_RETRY: 10
   RUST_BACKTRACE: 1
 jobs:
   check-integration:

--- a/.github/workflows/deadpool-redis.yml
+++ b/.github/workflows/deadpool-redis.yml
@@ -3,16 +3,15 @@ defaults:
     working-directory: ./crates/deadpool-redis
 env:
   RUST_BACKTRACE: 1
-permissions: {}
 jobs:
   check-integration:
     name: Check integration
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           components: rustc,rust-std,cargo
           toolchain: stable
@@ -33,24 +32,24 @@ jobs:
     name: Check re-exported features
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           components: rustc,rust-std,cargo
           toolchain: stable
-      - uses: dcarbone/install-jq-action@b7ef57d46ece78760b4019dbc4080a1ba2a40b45 # v3.2.0
-      - uses: dcarbone/install-yq-action@4075b4dca348d74bd83f2bf82d30f25d7c54539b # v1.3.1
+      - uses: dcarbone/install-jq-action@b7ef57d46ece78760b4019dbc4080a1ba2a40b45
+      - uses: dcarbone/install-yq-action@4075b4dca348d74bd83f2bf82d30f25d7c54539b
       - run: ../../tools/check-reexported-features.sh
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           components: rustc,rust-std,cargo,clippy
           toolchain: stable
@@ -59,14 +58,14 @@ jobs:
     name: MSRV
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           components: rustc,rust-std,cargo
           toolchain: nightly
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           components: rustc,rust-std,cargo
           toolchain: "1.85"
@@ -76,10 +75,10 @@ jobs:
     name: Doc
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           components: rustc,rust-std,cargo
           toolchain: stable
@@ -88,10 +87,10 @@ jobs:
     name: rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           components: rustc,rust-std,cargo,rustfmt
           toolchain: stable
@@ -115,10 +114,10 @@ jobs:
         ports:
           - 26379:26379
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           components: rustc,rust-std,cargo
           toolchain: stable
@@ -145,3 +144,4 @@ name: deadpool-redis
       - .github/workflows/deadpool-redis.yml
     tags:
       - deadpool-redis-v*
+permissions: {}

--- a/.github/workflows/deadpool-redis.yml
+++ b/.github/workflows/deadpool-redis.yml
@@ -2,6 +2,7 @@ defaults:
   run:
     working-directory: ./crates/deadpool-redis
 env:
+  CARGO_NET_RETRY: 10
   RUST_BACKTRACE: 1
 jobs:
   check-integration:

--- a/.github/workflows/deadpool-runtime.yml
+++ b/.github/workflows/deadpool-runtime.yml
@@ -3,16 +3,15 @@ defaults:
     working-directory: ./crates/deadpool-runtime
 env:
   RUST_BACKTRACE: 1
-permissions: {}
 jobs:
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           components: rustc,rust-std,cargo,clippy
           toolchain: stable
@@ -21,14 +20,14 @@ jobs:
     name: MSRV
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           components: rustc,rust-std,cargo
           toolchain: nightly
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           components: rustc,rust-std,cargo
           toolchain: "1.85"
@@ -38,10 +37,10 @@ jobs:
     name: Doc
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           components: rustc,rust-std,cargo
           toolchain: stable
@@ -50,10 +49,10 @@ jobs:
     name: rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           components: rustc,rust-std,cargo,rustfmt
           toolchain: stable
@@ -63,10 +62,10 @@ jobs:
     runs-on: ubuntu-latest
     services: {}
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           components: rustc,rust-std,cargo
           toolchain: stable
@@ -88,3 +87,4 @@ name: deadpool-runtime
       - .github/workflows/deadpool-runtime.yml
     tags:
       - deadpool-runtime-v*
+permissions: {}

--- a/.github/workflows/deadpool-runtime.yml
+++ b/.github/workflows/deadpool-runtime.yml
@@ -2,6 +2,7 @@ defaults:
   run:
     working-directory: ./crates/deadpool-runtime
 env:
+  CARGO_NET_RETRY: 10
   RUST_BACKTRACE: 1
 jobs:
   clippy:

--- a/.github/workflows/deadpool-sqlite.yml
+++ b/.github/workflows/deadpool-sqlite.yml
@@ -3,16 +3,15 @@ defaults:
     working-directory: ./crates/deadpool-sqlite
 env:
   RUST_BACKTRACE: 1
-permissions: {}
 jobs:
   check-integration:
     name: Check integration
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           components: rustc,rust-std,cargo
           toolchain: stable
@@ -32,24 +31,24 @@ jobs:
     name: Check re-exported features
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           components: rustc,rust-std,cargo
           toolchain: stable
-      - uses: dcarbone/install-jq-action@b7ef57d46ece78760b4019dbc4080a1ba2a40b45 # v3.2.0
-      - uses: dcarbone/install-yq-action@4075b4dca348d74bd83f2bf82d30f25d7c54539b # v1.3.1
+      - uses: dcarbone/install-jq-action@b7ef57d46ece78760b4019dbc4080a1ba2a40b45
+      - uses: dcarbone/install-yq-action@4075b4dca348d74bd83f2bf82d30f25d7c54539b
       - run: ../../tools/check-reexported-features.sh
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           components: rustc,rust-std,cargo,clippy
           toolchain: stable
@@ -58,14 +57,14 @@ jobs:
     name: MSRV
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           components: rustc,rust-std,cargo
           toolchain: nightly
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           components: rustc,rust-std,cargo
           toolchain: "1.85"
@@ -75,10 +74,10 @@ jobs:
     name: Doc
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           components: rustc,rust-std,cargo
           toolchain: stable
@@ -87,10 +86,10 @@ jobs:
     name: rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           components: rustc,rust-std,cargo,rustfmt
           toolchain: stable
@@ -100,10 +99,10 @@ jobs:
     runs-on: ubuntu-latest
     services: {}
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           components: rustc,rust-std,cargo
           toolchain: stable
@@ -125,3 +124,4 @@ name: deadpool-sqlite
       - .github/workflows/deadpool-sqlite.yml
     tags:
       - deadpool-sqlite-v*
+permissions: {}

--- a/.github/workflows/deadpool-sqlite.yml
+++ b/.github/workflows/deadpool-sqlite.yml
@@ -2,6 +2,7 @@ defaults:
   run:
     working-directory: ./crates/deadpool-sqlite
 env:
+  CARGO_NET_RETRY: 10
   RUST_BACKTRACE: 1
 jobs:
   check-integration:

--- a/.github/workflows/deadpool-sync.yml
+++ b/.github/workflows/deadpool-sync.yml
@@ -3,16 +3,15 @@ defaults:
     working-directory: ./crates/deadpool-sync
 env:
   RUST_BACKTRACE: 1
-permissions: {}
 jobs:
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           components: rustc,rust-std,cargo,clippy
           toolchain: stable
@@ -21,14 +20,14 @@ jobs:
     name: MSRV
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           components: rustc,rust-std,cargo
           toolchain: nightly
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           components: rustc,rust-std,cargo
           toolchain: "1.85"
@@ -38,10 +37,10 @@ jobs:
     name: Doc
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           components: rustc,rust-std,cargo
           toolchain: stable
@@ -50,10 +49,10 @@ jobs:
     name: rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           components: rustc,rust-std,cargo,rustfmt
           toolchain: stable
@@ -63,10 +62,10 @@ jobs:
     runs-on: ubuntu-latest
     services: {}
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           components: rustc,rust-std,cargo
           toolchain: stable
@@ -88,3 +87,4 @@ name: deadpool-sync
       - .github/workflows/deadpool-sync.yml
     tags:
       - deadpool-sync-v*
+permissions: {}

--- a/.github/workflows/deadpool-sync.yml
+++ b/.github/workflows/deadpool-sync.yml
@@ -2,6 +2,7 @@ defaults:
   run:
     working-directory: ./crates/deadpool-sync
 env:
+  CARGO_NET_RETRY: 10
   RUST_BACKTRACE: 1
 jobs:
   clippy:

--- a/.github/workflows/deadpool.yml
+++ b/.github/workflows/deadpool.yml
@@ -3,16 +3,15 @@ defaults:
     working-directory: ./crates/deadpool
 env:
   RUST_BACKTRACE: 1
-permissions: {}
 jobs:
   check-deadpool:
     name: Check deadpool
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           components: rustc,rust-std,cargo
           toolchain: stable
@@ -31,10 +30,10 @@ jobs:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           components: rustc,rust-std,cargo,clippy
           toolchain: stable
@@ -43,14 +42,14 @@ jobs:
     name: MSRV
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           components: rustc,rust-std,cargo
           toolchain: nightly
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           components: rustc,rust-std,cargo
           toolchain: "1.85"
@@ -60,10 +59,10 @@ jobs:
     name: Doc
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           components: rustc,rust-std,cargo
           toolchain: stable
@@ -72,10 +71,10 @@ jobs:
     name: rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           components: rustc,rust-std,cargo,rustfmt
           toolchain: stable
@@ -85,10 +84,10 @@ jobs:
     runs-on: ubuntu-latest
     services: {}
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
           components: rustc,rust-std,cargo
           toolchain: stable
@@ -110,3 +109,4 @@ name: deadpool
       - .github/workflows/deadpool.yml
     tags:
       - deadpool-v*
+permissions: {}

--- a/.github/workflows/deadpool.yml
+++ b/.github/workflows/deadpool.yml
@@ -2,6 +2,7 @@ defaults:
   run:
     working-directory: ./crates/deadpool
 env:
+  CARGO_NET_RETRY: 10
   RUST_BACKTRACE: 1
 jobs:
   check-deadpool:

--- a/ci.jsonnet
+++ b/ci.jsonnet
@@ -44,6 +44,7 @@ local genFeaturesFlag(features) =
 
 {
   name: crate,
+  permissions: {},
   on: {
     push: {
         branches: [ "main" ],
@@ -74,10 +75,11 @@ local genFeaturesFlag(features) =
       "runs-on": "ubuntu-latest",
       steps: [
         {
-          uses: "actions/checkout@v5"
+          uses: "actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd", // v5.0.1
+          with: { "persist-credentials": false },
         },
         {
-          uses: "dtolnay/rust-toolchain@v1",
+          uses: "dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9", // v1
           with: {
             toolchain: "stable",
             components: "rustc,rust-std,cargo,clippy",
@@ -93,10 +95,11 @@ local genFeaturesFlag(features) =
       "runs-on": "ubuntu-latest",
       steps: [
         {
-          uses: "actions/checkout@v5",
+          uses: "actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd", // v5.0.1
+          with: { "persist-credentials": false },
         },
         {
-          uses: "dtolnay/rust-toolchain@v1",
+          uses: "dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9", // v1
           with: {
             toolchain: "stable",
             components: "rustc,rust-std,cargo,rustfmt",
@@ -124,9 +127,12 @@ local genFeaturesFlag(features) =
       },
       "runs-on": "${{ matrix.os }}",
       steps: [
-        { uses: "actions/checkout@v5" },
         {
-          uses: "dtolnay/rust-toolchain@v1",
+          uses: "actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd", // v5.0.1
+          with: { "persist-credentials": false },
+        },
+        {
+          uses: "dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9", // v1
           with: {
             toolchain: "stable",
             components: "rustc,rust-std,cargo",
@@ -146,17 +152,18 @@ local genFeaturesFlag(features) =
       "runs-on": "ubuntu-latest",
       steps: [
         {
-          uses: "actions/checkout@v5"
+          uses: "actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd", // v5.0.1
+          with: { "persist-credentials": false },
         },
         {
-          uses: "dtolnay/rust-toolchain@v1",
+          uses: "dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9", // v1
           with: {
             toolchain: "nightly",
             components: "rustc,rust-std,cargo",
           }
         },
         {
-          uses: "dtolnay/rust-toolchain@v1",
+          uses: "dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9", // v1
           with: {
             toolchain: rust_version,
             components: "rustc,rust-std,cargo",
@@ -177,10 +184,11 @@ local genFeaturesFlag(features) =
       services: test_services,
       steps: [
         {
-          uses: "actions/checkout@v5",
+          uses: "actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd", // v5.0.1
+          with: { "persist-credentials": false },
         },
         {
-          uses: "dtolnay/rust-toolchain@v1",
+          uses: "dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9", // v1
           with: {
             toolchain: "stable",
             components: "rustc,rust-std,cargo",
@@ -197,16 +205,23 @@ local genFeaturesFlag(features) =
       name: "Check re-exported features",
       "runs-on": "ubuntu-latest",
       steps: [
-        { uses: "actions/checkout@v5" },
         {
-          uses: "dtolnay/rust-toolchain@v1",
+          uses: "actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd", // v5.0.1
+          with: { "persist-credentials": false },
+        },
+        {
+          uses: "dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9", // v1
           with: {
             toolchain: "stable",
             components: "rustc,rust-std,cargo",
           }
         },
-        { uses: "dcarbone/install-jq-action@v3" },
-        { uses: "dcarbone/install-yq-action@v1" },
+        {
+          uses: "dcarbone/install-jq-action@b7ef57d46ece78760b4019dbc4080a1ba2a40b45", // v3.2.0
+        },
+        {
+          uses: "dcarbone/install-yq-action@4075b4dca348d74bd83f2bf82d30f25d7c54539b", // v1.3.1
+        },
         { run: "../../tools/check-reexported-features.sh" },
       ]
     },
@@ -220,10 +235,11 @@ local genFeaturesFlag(features) =
       "runs-on": "ubuntu-latest",
       steps: [
         {
-          uses: "actions/checkout@v5",
+          uses: "actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd", // v5.0.1
+          with: { "persist-credentials": false },
         },
         {
-          uses: "dtolnay/rust-toolchain@v1",
+          uses: "dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9", // v1
           with: {
             toolchain: "stable",
             components: "rustc,rust-std,cargo",

--- a/ci.jsonnet
+++ b/ci.jsonnet
@@ -57,6 +57,7 @@ local genFeaturesFlag(features) =
     }
   },
   env: {
+    CARGO_NET_RETRY: 10,
     RUST_BACKTRACE: 1
   },
   defaults: {

--- a/crates/deadpool-lapin/CHANGELOG.md
+++ b/crates/deadpool-lapin/CHANGELOG.md
@@ -12,8 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update `lapin` dependency to version `4`
 - Remove `async-std` support
 - Bump up MSRV to `1.88` and Rust edition to `2024`
-- Re-export `lapin` feature:
-    - `hickory-dns`
+- Re-export `lapin` features:
+  - `hickory-dns`
+  - `rustls-platform-verifier`
 
 ## [0.13.1] - 2024-08-11
 

--- a/crates/deadpool-lapin/Cargo.toml
+++ b/crates/deadpool-lapin/Cargo.toml
@@ -31,6 +31,7 @@ rustls = ["lapin/rustls"]
 rustls--aws_lc_rs = ["lapin/rustls--aws_lc_rs"]
 rustls--ring = ["lapin/rustls--ring"]
 rustls-native-certs = ["lapin/rustls-native-certs"]
+rustls-platform-verifier = ["lapin/rustls-platform-verifier"]
 rustls-webpki-roots-certs = ["lapin/rustls-webpki-roots-certs"]
 vendored-openssl = ["lapin/vendored-openssl"]
 

--- a/crates/deadpool-postgres/CHANGELOG.md
+++ b/crates/deadpool-postgres/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Bump up MSRV to `1.85` and Rust edition to `2024`
-- Re-export `tokio_postgres` features
+- Re-export `tokio-postgres` features:
+  - `with-bit-vec-0_9`
 - Update `tokio-postgres` dependency to version `0.7.14`
 
 ## [0.14.1] - 2024-12-18

--- a/crates/deadpool-postgres/Cargo.toml
+++ b/crates/deadpool-postgres/Cargo.toml
@@ -27,6 +27,7 @@ runtime = ["tokio-postgres/runtime"]
 with-bit-vec-0_6 = ["tokio-postgres/with-bit-vec-0_6"]
 with-bit-vec-0_7 = ["tokio-postgres/with-bit-vec-0_7"]
 with-bit-vec-0_8 = ["tokio-postgres/with-bit-vec-0_8"]
+with-bit-vec-0_9 = ["tokio-postgres/with-bit-vec-0_9"]
 with-chrono-0_4 = ["tokio-postgres/with-chrono-0_4"]
 with-cidr-0_2 = ["tokio-postgres/with-cidr-0_2"]
 with-cidr-0_3 = ["tokio-postgres/with-cidr-0_3"]
@@ -59,7 +60,7 @@ tracing = "0.1.37"
 tokio-postgres = "0.7.14"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-getrandom = { package = "getrandom", version = "0.3", features = ["wasm_js"] }
+getrandom = { package = "getrandom", version = "0.4", features = ["wasm_js"] }
 tokio-postgres = { version = "0.7.14", default-features = false }
 
 [dev-dependencies]

--- a/crates/deadpool-postgres/ci.config.yml
+++ b/crates/deadpool-postgres/ci.config.yml
@@ -41,8 +41,10 @@ jobs:
           - --features rt_tokio_1,serde
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@v1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
           toolchain: stable
           targets: wasm32-unknown-unknown

--- a/crates/deadpool-redis/CHANGELOG.md
+++ b/crates/deadpool-redis/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Add `Manager::new_with_config` method
+- Update `redis` dependency to version `1.2`
 - Re-export `redis` features:
   - `entra-id`
   - `token-based-authentication`

--- a/crates/deadpool-redis/Cargo.toml
+++ b/crates/deadpool-redis/Cargo.toml
@@ -57,7 +57,7 @@ vector-sets = ["redis/vector-sets"]
 deadpool = { path = "../deadpool", version = "0.13.0", default-features = false, features = [
     "managed",
 ] }
-redis = { version = "1.0.4", default-features = false, features = ["aio"] }
+redis = { version = "1.2", default-features = false, features = ["aio"] }
 serde = { package = "serde", version = "1.0", features = [
     "derive",
 ], optional = true }

--- a/crates/deadpool-redis/src/cluster/mod.rs
+++ b/crates/deadpool-redis/src/cluster/mod.rs
@@ -7,7 +7,10 @@ use std::{
 };
 
 use deadpool::managed;
-use redis::{IntoConnectionInfo, RedisError, RedisResult, aio::ConnectionLike};
+use redis::{
+    IntoConnectionInfo, RedisError, RedisResult, aio::ConnectionLike,
+    cluster_read_routing::RandomReplicaStrategy,
+};
 
 use redis;
 pub use redis::cluster::{ClusterClient, ClusterClientBuilder};
@@ -139,7 +142,7 @@ impl Manager {
     ) -> RedisResult<Self> {
         let mut client = ClusterClientBuilder::new(params);
         if read_from_replicas {
-            client = client.read_from_replicas();
+            client = client.read_routing_strategy(RandomReplicaStrategy);
         }
         Ok(Self {
             client: client.build()?,

--- a/crates/deadpool/ci.config.yml
+++ b/crates/deadpool/ci.config.yml
@@ -13,8 +13,10 @@ jobs:
           - serde
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@v1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
           toolchain: stable
           components: rustc,rust-std,cargo

--- a/gen-ci.sh
+++ b/gen-ci.sh
@@ -1,10 +1,14 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 
 for CRATE_PATH in crates/*; do
     CRATE_NAME=$(basename "${CRATE_PATH}")
     CARGO_TOML="${CRATE_PATH}/Cargo.toml"
+    if [ ! -f "$CARGO_TOML" ]; then
+        continue
+    fi
+
     CI_CONFIG_YML="${CRATE_PATH}/ci.config.yml"
     WORKFLOW_YML=.github/workflows/${CRATE_NAME}.yml
     echo ${WORKFLOW_YML}


### PR DESCRIPTION
The recent changes in #482 weren't applied to the CI generation layer. First commit here doesn't change any behavior, just copies the changes to the jsonnet layer.

Second commit resolves all the pre-existing CI issues. Mainly version bumps and feature re-exports.
