### PR TITLE
chore: add the ability to pass pool timeouts into memcached pool builder

### DIFF
--- a/crates/deadpool-memcached/CHANGELOG.md
+++ b/crates/deadpool-memcached/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update `async-memcached` dependency to version `0.6`
 - Bump up MSRV to `1.85` and Rust edition to `2024`
+- Add `Runtime` parameter to `Config::create_pool` so pool timeouts
+  (`wait`, `create`, `recycle`) configured via `PoolConfig::timeouts` are
+  honored. **Breaking:** `Config::create_pool` now takes
+  `Option<Runtime>`.
 
 ## [0.4.0] - 2025-09-02
 

--- a/crates/deadpool-memcached/src/config.rs
+++ b/crates/deadpool-memcached/src/config.rs
@@ -1,6 +1,6 @@
 use std::convert::Infallible;
 
-use crate::{CreatePoolError, Manager, Pool, PoolBuilder, PoolConfig};
+use crate::{CreatePoolError, Manager, Pool, PoolBuilder, PoolConfig, Runtime};
 
 /// Configuration object.
 ///
@@ -49,14 +49,21 @@ impl Config {
 
     /// Creates a new [`Pool`] using this [`Config`].
     ///
+    /// A [`Runtime`] is required if any [`Timeouts`] are configured on the
+    /// [`PoolConfig`] (`wait`, `create` or `recycle`). Pass `None` if you do
+    /// not need timeouts.
+    ///
+    /// [`Timeouts`]: deadpool::managed::Timeouts
+    ///
     /// # Errors
     ///
     /// See [`CreatePoolError`] for details.
-    pub fn create_pool(&self) -> Result<Pool, CreatePoolError> {
-        self.builder()
-            .map_err(CreatePoolError::Config)?
-            .build()
-            .map_err(CreatePoolError::Build)
+    pub fn create_pool(&self, runtime: Option<Runtime>) -> Result<Pool, CreatePoolError> {
+        let mut builder = self.builder().map_err(CreatePoolError::Config)?;
+        if let Some(runtime) = runtime {
+            builder = builder.runtime(runtime);
+        }
+        builder.build().map_err(CreatePoolError::Build)
     }
 
     /// Creates a new [`PoolBuilder`] using this [`Config`].


### PR DESCRIPTION
This changes the public API and might be an awful idea - this is how I find out :) Fixes https://github.com/deadpool-rs/deadpool/issues/493